### PR TITLE
Photo MVP Week 5: credit wallet + Stripe Checkout

### DIFF
--- a/MVP_PHOTO_PLAN.md
+++ b/MVP_PHOTO_PLAN.md
@@ -4,22 +4,27 @@
 **Product owner:** Rey (CEO) — see `PRD.md` for full Founder-Grade PRD
 **Engineering owner:** Claude
 **Target:** Paying-customer MVP launch — end of Month 2 (~8 weeks)
-**Last session:** 2026-04-19 — finished Week 1 → Week 4 end-to-end (infra side of Week 3). See [§8 Updates log](#8-updates-log).
+**Last session:** 2026-04-19 — Weeks 1 → 5 code-complete. Week 5 blocked only on Rey creating Stripe credit-pack SKUs. See [§8 Updates log](#8-updates-log).
 
 > ## 🎯 Where we left off (2026-04-19)
 >
-> Weeks 1, 2, and 4 are code-complete. Week 3's `PhotoModelProvider` abstraction
-> and the `enhance` consumer handler are in place; the remaining Week 3 items
-> (white balance, perspective, sky replace, window pull) are each a new handler
-> plugged into the same provider interface.
+> Weeks 1, 2, 4, and 5 are code-complete. Week 3 is infra-complete (provider +
+> enhance); remaining Week 3 items (white balance, perspective, sky replace,
+> window pull) are each a new handler on the provider interface.
 >
-> **Next open task on the critical path:** white balance — ship gray-world as the
-> CPU default (uses the abstraction), then start the model bakeoff to pin a
-> Replicate version for the ML path.
+> **Next open tasks on the critical path:**
+> 1. **Rey — Stripe dashboard:** create 3 one-time products (Starter $49/100 credits,
+>    Growth $199/500 credits, Agency $699/2000 credits), then fill the
+>    `VITE_STRIPE_PHOTO_{STARTER,GROWTH,AGENCY}_PACK_PRICE_ID` envs (test + live).
+>    Without these the buy-credits modal shows "not configured yet."
+> 2. **Claude — Week 6:** unlock-download endpoint that debits credits via
+>    `photoCreditService.chargeForDownload`, serves the non-watermarked URL,
+>    then batch ZIP export.
+> 3. **Claude — Week 3 tail:** white-balance handler (gray-world CPU default).
 >
 > **Quality gates green:** `npm run check` clean. HDR → enhance chain works
-> end-to-end locally (enhance falls back to Sharp tone curve when
-> `REPLICATE_API_TOKEN` is unset).
+> end-to-end locally. Credit ledger debit is transactional (SELECT FOR UPDATE).
+> Webhook idempotency keyed on stripe_charge_id.
 >
 > **Dev ops reminder:** Cloud Run staging service is provisioned but **off**;
 > Cloud SQL stays off between sessions; local Docker Postgres is the dev DB.
@@ -129,11 +134,11 @@ reuses what works.
 
 ### Month 2 (Weeks 5–8) — Billing + download + MVP launch
 
-**Week 5 — Credit wallet + Stripe wiring**
-- [ ] New Stripe price SKUs (credit pack tiers)
-- [ ] Photo-credit ledger writes on grant, purchase, debit, refund
-- [ ] Org-level balance display
-- [ ] Checkout flow: Stripe Checkout → webhook → ledger credit
+**Week 5 — Credit wallet + Stripe wiring** 🟡 _code-complete 2026-04-19; Stripe dashboard SKUs pending_
+- [x] New Stripe price SKUs (credit pack tiers) _(env scaffolding: `VITE_STRIPE_PHOTO_{STARTER,GROWTH,AGENCY}_PACK_PRICE_ID` + LIVE variants; packs with empty priceId are filtered out of the UI so no broken "buy" buttons). **Action for Rey:** create the 3 one-time products in Stripe dashboard and fill the envs)_
+- [x] Photo-credit ledger writes on grant, purchase, debit, refund _(`photoCreditService` — append-only rows, `balanceAfter` cached for O(1) reads; debit uses `SELECT ... FOR UPDATE` inside a transaction to prevent concurrent overdraft)_
+- [x] Org-level balance display _(`GET /api/photo/credits/balance` + `CreditsChip` in both `/photos` and `/photos/:id` headers; low/zero balance tinted amber/red as a top-up nudge)_
+- [x] Checkout flow: Stripe Checkout → webhook → ledger credit _(one-time `mode:payment` Checkout session with orgId/userId/packId metadata; webhook delegates via `subscription-service.handleWebhook` → `photoCreditService.handleWebhookEvent`; idempotent on `stripe_charge_id` so Stripe retries don't double-grant; priceId verified against catalog before grant so tampered metadata can't inflate credits)_
 
 **Week 6 — Pay-on-download + delivery**
 - [ ] Unlock-download endpoint (debits credits, returns non-watermarked URL)
@@ -247,6 +252,22 @@ processing success rate
   SIGTERM-safe graceful shutdown. Simplified Mertens HDR fusion handler
   (~200ms for 5 exposures, 1920px preview, watermark SVG composite).
   Groups + merged assets + editVersions persisted atomically.
+- **2026-04-19 — Week 5 code-complete.** Photo-credit wallet shipped end to
+  end: `photo-credit-service` with append-only ledger, transactional debit
+  (SELECT FOR UPDATE prevents concurrent overdraft), idempotent purchase
+  grants (keyed on `stripe_charge_id`), Stripe Checkout session creation
+  (mode=payment, not subscription — deliberately separate from the
+  ad-generator's recurring SKUs). Webhook delegates via
+  `subscription-service.handleWebhook` (photo service inspects
+  `metadata.source=photo_credit_pack` and either claims the event or
+  returns false so subscription logic runs). Route endpoints: `GET
+  /credits/packs`, `GET /credits/balance`, `GET /credits/ledger`, `POST
+  /credits/checkout`. Client: `CreditsChip` component in both `/photos` and
+  `/photos/:id` headers (amber tint <10, red tint at 0), `BuyCreditsModal`
+  with pack picker → Stripe redirect, post-redirect balance invalidation at
+  1.5s + 5s to catch slow webhooks. **Open on critical path:** Rey creates
+  the 3 one-time-price products in Stripe dashboard and sets the env vars;
+  then Week 6 unlock-download endpoint + ZIP export.
 - **2026-04-19 — Week 3 infra + Week 4 shipped.** Built `PhotoModelProvider`
   abstraction (`server/services/photo-providers/*`) with Replicate + local
   fallback providers, selected by env. Added `enhance` consumer handler with a

--- a/client/src/components/photos/credits-chip.tsx
+++ b/client/src/components/photos/credits-chip.tsx
@@ -1,0 +1,267 @@
+/**
+ * CreditsChip — header pill showing the current org's photo credit balance,
+ * with a "Buy credits" button that opens the pack-picker modal.
+ *
+ * Shows in every /photos/* page header. Balance is fetched via TanStack
+ * Query so it stays fresh across tabs (refetchOnWindowFocus default) and
+ * gets invalidated by post-purchase redirect handling + successful downloads.
+ *
+ * Design notes:
+ *  - We keep this compact (icon + number + button) so it fits next to other
+ *    page-level CTAs without pushing the primary action offscreen on mobile.
+ *  - Low-balance state (< 10) shows an amber tint to nudge a top-up before
+ *    the user hits zero mid-delivery.
+ *  - Zero-balance state shows red and auto-opens the modal on click of the
+ *    chip body, not just the button, to reduce friction.
+ */
+
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { Coins, Plus, Loader2, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { apiRequest } from "@/lib/queryClient";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type BalanceResponse = { orgId: string; balance: number };
+
+interface CreditPack {
+  id: "starter" | "growth" | "agency";
+  name: string;
+  credits: number;
+  displayPriceUsd: number;
+  priceId: string;
+  description: string;
+}
+
+type PacksResponse = { packs: CreditPack[] };
+
+type CheckoutResponse = { sessionId: string; url: string };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chip
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function CreditsChip() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const { data, isLoading } = useQuery<BalanceResponse>({
+    queryKey: ["/api/photo/credits/balance"],
+  });
+
+  const balance = data?.balance ?? 0;
+  const tone = toneForBalance(balance, isLoading);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setModalOpen(true)}
+        className={[
+          "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+          tone.border,
+          tone.bg,
+          tone.text,
+          "hover:shadow-sm",
+        ].join(" ")}
+        data-testid="credits-chip"
+        aria-label={`Photo credits: ${balance}`}
+      >
+        <Coins className="w-4 h-4" />
+        {isLoading ? (
+          <span className="flex items-center gap-1.5">
+            <Loader2 className="w-3 h-3 animate-spin" /> Loading…
+          </span>
+        ) : (
+          <>
+            <span className="tabular-nums">{balance.toLocaleString()}</span>
+            <span className="opacity-70">credits</span>
+          </>
+        )}
+        <span className="mx-1 opacity-40">·</span>
+        <span className="inline-flex items-center gap-0.5">
+          <Plus className="w-3 h-3" />
+          Buy
+        </span>
+      </button>
+
+      <BuyCreditsModal open={modalOpen} onOpenChange={setModalOpen} />
+    </>
+  );
+}
+
+function toneForBalance(balance: number, loading: boolean) {
+  if (loading) {
+    return {
+      bg: "bg-gray-50",
+      border: "border-gray-200",
+      text: "text-ailldoit-muted",
+    };
+  }
+  if (balance <= 0) {
+    return {
+      bg: "bg-red-50",
+      border: "border-red-200",
+      text: "text-red-700",
+    };
+  }
+  if (balance < 10) {
+    return {
+      bg: "bg-amber-50",
+      border: "border-amber-200",
+      text: "text-amber-800",
+    };
+  }
+  return {
+    bg: "bg-emerald-50",
+    border: "border-emerald-200",
+    text: "text-emerald-800",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Modal
+// ─────────────────────────────────────────────────────────────────────────────
+
+function BuyCreditsModal({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const [selected, setSelected] = useState<CreditPack["id"]>("growth");
+
+  const { data: packsData, isLoading: packsLoading } = useQuery<PacksResponse>({
+    queryKey: ["/api/photo/credits/packs"],
+    enabled: open,
+  });
+
+  const checkoutMutation = useMutation({
+    mutationFn: async (packId: CreditPack["id"]) => {
+      const res = await apiRequest("POST", "/api/photo/credits/checkout", {
+        packId,
+      });
+      return (await res.json()) as CheckoutResponse;
+    },
+    onSuccess: (data) => {
+      // Hard navigation — Stripe Checkout is a separate domain.
+      window.location.href = data.url;
+    },
+  });
+
+  const packs = packsData?.packs ?? [];
+  const noPacksConfigured = !packsLoading && packs.length === 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Buy photo credits</DialogTitle>
+          <DialogDescription>
+            Credits are spent only when you download a full-resolution, unwatermarked image.
+            Watermarked previews are always free.
+          </DialogDescription>
+        </DialogHeader>
+
+        {packsLoading ? (
+          <div className="py-10 flex items-center justify-center text-ailldoit-muted">
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            Loading credit packs…
+          </div>
+        ) : noPacksConfigured ? (
+          <div className="py-10 text-center text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-md px-4">
+            Credit packs are not configured yet. Please check back shortly.
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-3">
+            {packs.map((pack) => {
+              const isSelected = selected === pack.id;
+              return (
+                <button
+                  key={pack.id}
+                  type="button"
+                  onClick={() => setSelected(pack.id)}
+                  className={[
+                    "text-left rounded-lg border p-4 transition-all",
+                    isSelected
+                      ? "border-ailldoit-accent ring-2 ring-ailldoit-accent/30 bg-ailldoit-accent/5"
+                      : "border-gray-200 hover:border-gray-300",
+                  ].join(" ")}
+                  data-testid={`pack-${pack.id}`}
+                >
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <div className="font-semibold text-ailldoit-black">{pack.name}</div>
+                      <div className="text-2xl font-bold mt-1">
+                        ${pack.displayPriceUsd}
+                      </div>
+                      <div className="text-xs text-ailldoit-muted mt-0.5">
+                        ${(pack.displayPriceUsd / pack.credits).toFixed(2)} / credit
+                      </div>
+                    </div>
+                    {isSelected && (
+                      <Check className="w-5 h-5 text-ailldoit-accent flex-shrink-0" />
+                    )}
+                  </div>
+                  <div className="mt-3 text-sm font-medium">
+                    {pack.credits.toLocaleString()} credits
+                  </div>
+                  <div className="mt-1 text-xs text-ailldoit-muted leading-snug">
+                    {pack.description}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={checkoutMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => checkoutMutation.mutate(selected)}
+            disabled={
+              packsLoading ||
+              noPacksConfigured ||
+              checkoutMutation.isPending
+            }
+            className="bg-ailldoit-accent hover:bg-ailldoit-accent/90 text-white"
+          >
+            {checkoutMutation.isPending ? (
+              <span className="inline-flex items-center">
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Redirecting to Stripe…
+              </span>
+            ) : (
+              "Continue to checkout"
+            )}
+          </Button>
+        </DialogFooter>
+
+        {checkoutMutation.isError && (
+          <p className="text-sm text-red-700 mt-2">
+            Couldn't start checkout:{" "}
+            {checkoutMutation.error instanceof Error
+              ? checkoutMutation.error.message
+              : "unknown error"}
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/photos/detail.tsx
+++ b/client/src/pages/photos/detail.tsx
@@ -20,6 +20,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import type { PhotoAsset, PhotoProject } from "@shared/schema";
+import { CreditsChip } from "@/components/photos/credits-chip";
 
 /**
  * /photos/:id — project detail screen.
@@ -123,7 +124,10 @@ export default function PhotosDetail() {
               {project?.name ?? "Project"}
             </h2>
           </div>
-          {id && project ? <TestQueueButton projectId={id} /> : null}
+          <div className="flex items-center gap-3">
+            <CreditsChip />
+            {id && project ? <TestQueueButton projectId={id} /> : null}
+          </div>
         </div>
       </header>
 

--- a/client/src/pages/photos/index.tsx
+++ b/client/src/pages/photos/index.tsx
@@ -13,6 +13,10 @@ import {
   Loader2,
 } from "lucide-react";
 import type { PhotoProject } from "@shared/schema";
+import { CreditsChip } from "@/components/photos/credits-chip";
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useLocation } from "wouter";
 
 /**
  * Photos — real-estate AI photo editing module (landing page).
@@ -41,6 +45,40 @@ export default function PhotosIndex() {
   const projects = data?.projects ?? [];
   const hasProjects = projects.length > 0;
 
+  // Post-checkout redirect handling. Stripe sends users back to
+  // /photos?checkout=success&session_id=cs_... — invalidate the balance
+  // query so the chip updates once the webhook has credited the org. We
+  // strip the query params so a refresh doesn't re-trigger the toast-y UX.
+  const [location, setLocation] = useLocation();
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const checkoutStatus = params.get("checkout");
+    if (!checkoutStatus) return;
+    if (checkoutStatus === "success") {
+      // The webhook may land slightly after the redirect — give it a beat,
+      // then refetch. A second invalidation after a longer delay catches
+      // the slow-webhook case without blocking the first paint.
+      setTimeout(
+        () =>
+          queryClient.invalidateQueries({
+            queryKey: ["/api/photo/credits/balance"],
+          }),
+        1500
+      );
+      setTimeout(
+        () =>
+          queryClient.invalidateQueries({
+            queryKey: ["/api/photo/credits/balance"],
+          }),
+        5000
+      );
+    }
+    // Clean the URL.
+    setLocation("/photos");
+  }, [location, queryClient, setLocation]);
+
   return (
     <div className="flex-1 overflow-hidden">
       {/* Header */}
@@ -53,6 +91,7 @@ export default function PhotosIndex() {
             </p>
           </div>
           <div className="flex items-center space-x-4">
+            <CreditsChip />
             <Link href="/photos/new">
               <Button className="bg-ailldoit-accent hover:bg-ailldoit-accent/90 text-white hover:shadow-lg">
                 <Plus className="w-4 h-4 mr-2" />

--- a/server/config/environment.ts
+++ b/server/config/environment.ts
@@ -5,8 +5,15 @@ export interface EnvironmentConfig {
   stripe: {
     secretKey: string;
     publicKey: string;
+    // Ad-generator subscription SKUs (recurring plans)
     starterPriceId: string;
     growthPriceId: string;
+    // Photo module credit-pack SKUs (one-time Checkout purchases).
+    // Packs are deliberately separate from the subscription SKUs — photo billing
+    // is pay-per-image via credits, not a recurring plan.
+    photoStarterPackPriceId: string;   // starter pack (e.g. 100 credits)
+    photoGrowthPackPriceId: string;    // growth  pack (e.g. 500 credits)
+    photoAgencyPackPriceId: string;    // agency  pack (e.g. 2000 credits)
     webhookSecret: string;
   };
 }
@@ -33,14 +40,27 @@ export function getEnvironmentConfig(): EnvironmentConfig {
       publicKey: useTestKeys 
         ? process.env.VITE_STRIPE_PUBLIC_KEY! 
         : process.env.VITE_STRIPE_LIVE_PUBLIC_KEY!,
-      starterPriceId: useTestKeys 
-        ? process.env.VITE_STRIPE_STARTER_PRICE_ID! 
+      starterPriceId: useTestKeys
+        ? process.env.VITE_STRIPE_STARTER_PRICE_ID!
         : process.env.VITE_STRIPE_LIVE_STARTER_PRICE_ID!,
-      growthPriceId: useTestKeys 
-        ? process.env.VITE_STRIPE_GROWTH_PRICE_ID! 
+      growthPriceId: useTestKeys
+        ? process.env.VITE_STRIPE_GROWTH_PRICE_ID!
         : process.env.VITE_STRIPE_LIVE_GROWTH_PRICE_ID!,
-      webhookSecret: useTestKeys 
-        ? process.env.STRIPE_WEBHOOK_SECRET! 
+      // Photo pack price IDs — fall back to "" when unset so the service can
+      // detect "packs not configured" and surface a friendly error instead of
+      // crashing at startup. Expect the three envs to be filled in once Rey
+      // has created the SKUs in Stripe dashboard.
+      photoStarterPackPriceId: useTestKeys
+        ? (process.env.VITE_STRIPE_PHOTO_STARTER_PACK_PRICE_ID ?? "")
+        : (process.env.VITE_STRIPE_LIVE_PHOTO_STARTER_PACK_PRICE_ID ?? ""),
+      photoGrowthPackPriceId: useTestKeys
+        ? (process.env.VITE_STRIPE_PHOTO_GROWTH_PACK_PRICE_ID ?? "")
+        : (process.env.VITE_STRIPE_LIVE_PHOTO_GROWTH_PACK_PRICE_ID ?? ""),
+      photoAgencyPackPriceId: useTestKeys
+        ? (process.env.VITE_STRIPE_PHOTO_AGENCY_PACK_PRICE_ID ?? "")
+        : (process.env.VITE_STRIPE_LIVE_PHOTO_AGENCY_PACK_PRICE_ID ?? ""),
+      webhookSecret: useTestKeys
+        ? process.env.STRIPE_WEBHOOK_SECRET!
         : process.env.STRIPE_LIVE_WEBHOOK_SECRET!
     }
   };

--- a/server/routes/photo-routes.ts
+++ b/server/routes/photo-routes.ts
@@ -22,6 +22,11 @@ import { bracketDetectionService } from "../services/bracket-detection-service";
 import { editJobService } from "../services/edit-job-service";
 import { editVersionService } from "../services/edit-version-service";
 import { enqueuePhotoJob } from "../queues/photo-queue";
+import {
+  photoCreditService,
+  getPhotoCreditPacks,
+  PackNotConfiguredError,
+} from "../services/photo-credit-service";
 
 // Uploads are held in memory so we can pipe buffers to Firebase Storage
 // without a disk hop. 25MB per file (pro-camera JPEGs run 8–20MB), up to
@@ -464,6 +469,108 @@ router.get("/projects/:id/jobs", async (req: Request, res: Response) => {
   } catch (error: any) {
     console.error("❌ PHOTO: Failed to list jobs", error);
     res.status(500).json({ message: "Failed to list jobs" });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Credits (Week 5) — org-scoped wallet backed by photo_credit_ledger
+// -----------------------------------------------------------------------------
+
+/**
+ * List available credit packs with display prices. Safe to call
+ * unauthenticated in the future (for a marketing page) but for now lives
+ * under /api/photo/* which requires auth. Packs with an unset Stripe
+ * priceId are filtered out so the UI never shows a "buy" button that
+ * wouldn't work.
+ */
+router.get("/credits/packs", async (_req: Request, res: Response) => {
+  try {
+    const packs = getPhotoCreditPacks().filter((p) => !!p.priceId);
+    res.json({ packs });
+  } catch (error: any) {
+    console.error("❌ PHOTO: Failed to list packs", error);
+    res.status(500).json({ message: "Failed to load credit packs" });
+  }
+});
+
+/**
+ * Return the active org's current credit balance. Drives the header chip.
+ * Cheap call — single row lookup on the ledger's newest entry for the org.
+ */
+router.get("/credits/balance", async (req: Request, res: Response) => {
+  try {
+    const balance = await photoCreditService.getBalance(req.orgId!);
+    res.json({ orgId: req.orgId, balance });
+  } catch (error: any) {
+    console.error("❌ PHOTO: Failed to read balance", error);
+    res.status(500).json({ message: "Failed to load credit balance" });
+  }
+});
+
+/**
+ * Recent ledger entries for the active org — transactions panel.
+ */
+router.get("/credits/ledger", async (req: Request, res: Response) => {
+  try {
+    const limit = Math.min(parseInt(String(req.query.limit ?? "50"), 10) || 50, 200);
+    const entries = await photoCreditService.listRecent(req.orgId!, limit);
+    res.json({ entries });
+  } catch (error: any) {
+    console.error("❌ PHOTO: Failed to list ledger", error);
+    res.status(500).json({ message: "Failed to load ledger" });
+  }
+});
+
+const checkoutBody = z.object({
+  packId: z.enum(["starter", "growth", "agency"]),
+  // Client provides these so we redirect back to the right route after
+  // Stripe Checkout. Keep them on the server-side of truth only via allow-list
+  // of our own domain in a later hardening pass.
+  successUrl: z.string().url().optional(),
+  cancelUrl: z.string().url().optional(),
+});
+
+/**
+ * Start a Stripe Checkout session for a credit pack. Returns a URL the
+ * client should navigate to. On success, Stripe redirects back to
+ * `successUrl` + session_id, and the webhook credits the org asynchronously.
+ */
+router.post("/credits/checkout", async (req: Request, res: Response) => {
+  try {
+    const parsed = checkoutBody.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        message: "Invalid request",
+        errors: parsed.error.flatten(),
+      });
+    }
+
+    if (!req.user?.email) {
+      return res.status(400).json({ message: "User email required for checkout" });
+    }
+
+    const origin = `${req.protocol}://${req.get("host")}`;
+    const { sessionId, url } = await photoCreditService.createCheckoutSession({
+      orgId: req.orgId!,
+      userId: req.user.id,
+      userEmail: req.user.email,
+      packId: parsed.data.packId,
+      successUrl:
+        parsed.data.successUrl ??
+        `${origin}/photos?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+      cancelUrl: parsed.data.cancelUrl ?? `${origin}/photos?checkout=cancelled`,
+    });
+
+    res.json({ sessionId, url });
+  } catch (error: any) {
+    if (error instanceof PackNotConfiguredError) {
+      return res.status(503).json({
+        message: "This credit pack is not available yet — please try a different pack.",
+        packId: error.packId,
+      });
+    }
+    console.error("❌ PHOTO: Failed to create checkout session", error);
+    res.status(500).json({ message: "Failed to start checkout" });
   }
 });
 

--- a/server/services/photo-credit-service.ts
+++ b/server/services/photo-credit-service.ts
@@ -1,0 +1,502 @@
+/**
+ * photo-credit-service — org-scoped credit wallet backed by photo_credit_ledger.
+ *
+ * Design principles
+ *  - **Append-only ledger.** Balance is derived from sum(delta) per org — we
+ *    never mutate rows. Every state change is auditable: grant, purchase,
+ *    download, refund, adjustment. `balanceAfter` is stored for fast reads
+ *    and serves as an integrity check (sum should match the latest row).
+ *  - **Debits are transactional.** The debit path (`chargeForDownload`) takes
+ *    a DB transaction, locks the latest ledger row for the org, verifies
+ *    sufficient balance, and writes the new row atomically. Two concurrent
+ *    downloads can't both pass the balance check and overdraw.
+ *  - **Org-scoped, not user-scoped.** Per PRD: credits belong to the
+ *    organization. Every query keys on orgId. userId is captured only as an
+ *    audit trail (who triggered the debit).
+ *  - **Stripe-agnostic core.** The ledger knows nothing about Stripe price
+ *    IDs or checkout sessions — it just records deltas. Stripe concerns
+ *    (Checkout session creation, webhook payload parsing) live in the
+ *    methods that bridge Stripe → ledger.
+ *
+ * Why not extend subscription-service? That service models per-user recurring
+ * plans for the ad-generator. Photo credits are org-scoped, one-time
+ * Checkout purchases, with a durable ledger rather than a user-row counter.
+ * Different domain, different failure modes — deliberately separate.
+ */
+
+import Stripe from "stripe";
+import { desc, eq } from "drizzle-orm";
+import { db } from "../db";
+import { ENV } from "../config/environment";
+import {
+  photoCreditLedger,
+  type PhotoCreditLedgerEntry,
+} from "@shared/schema";
+
+const stripe = new Stripe(ENV.stripe.secretKey, {
+  apiVersion: "2025-08-27.basil",
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Credit pack catalog
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Three tiers per PRD §10 + the AutoHDR benchmark ($0.45–$0.60/image). Pricing
+// numbers here are DISPLAY-ONLY — Stripe is the source of truth for what the
+// customer actually gets charged. The `credits` field is what we grant when
+// Stripe confirms the payment. Bumping this without bumping the Stripe price
+// breaks the value prop — they must be changed together.
+//
+// Keep these in sync with the SKUs in Stripe Dashboard. The map-by-priceId
+// lookup in `resolvePackByPriceId` is the guard: an unknown priceId aborts
+// the grant so we never credit for a SKU we don't recognise.
+
+export interface PhotoCreditPack {
+  id: "starter" | "growth" | "agency";
+  name: string;
+  credits: number;
+  displayPriceUsd: number; // for UI only — Stripe has final word
+  priceId: string;         // Stripe Price ID (test or live, via env)
+  description: string;
+}
+
+/**
+ * Return the pack catalog. Called per-request because ENV.stripe.*PriceId
+ * is resolved lazily via env (test vs live). Not cached so a dev restart
+ * picks up new envs without a code change.
+ */
+export function getPhotoCreditPacks(): PhotoCreditPack[] {
+  return [
+    {
+      id: "starter",
+      name: "Starter",
+      credits: 100,
+      displayPriceUsd: 49,
+      priceId: ENV.stripe.photoStarterPackPriceId,
+      description: "100 photo credits — good for ~5 listings",
+    },
+    {
+      id: "growth",
+      name: "Growth",
+      credits: 500,
+      displayPriceUsd: 199,
+      priceId: ENV.stripe.photoGrowthPackPriceId,
+      description: "500 photo credits — best value for active agents",
+    },
+    {
+      id: "agency",
+      name: "Agency",
+      credits: 2000,
+      displayPriceUsd: 699,
+      priceId: ENV.stripe.photoAgencyPackPriceId,
+      description: "2,000 photo credits — volume pricing for brokerages",
+    },
+  ];
+}
+
+function resolvePackByPriceId(priceId: string): PhotoCreditPack | null {
+  return getPhotoCreditPacks().find((p) => p.priceId && p.priceId === priceId) ?? null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a debit can't proceed because the org doesn't have enough
+ * credits. Callers (download endpoint) should catch this and respond 402
+ * Payment Required so the UI can prompt the user to top up.
+ */
+export class InsufficientCreditsError extends Error {
+  statusCode = 402;
+  constructor(public orgId: string, public required: number, public available: number) {
+    super(`Insufficient credits: required ${required}, available ${available}`);
+    this.name = "InsufficientCreditsError";
+  }
+}
+
+export class PackNotConfiguredError extends Error {
+  statusCode = 503;
+  constructor(public packId: string) {
+    super(`Photo credit pack '${packId}' is not configured — set its Stripe price ID env var`);
+    this.name = "PackNotConfiguredError";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class PhotoCreditService {
+  /**
+   * Read the org's current credit balance. Pulls the most recent ledger row
+   * and returns its balanceAfter — O(1) in practice (index on orgId+createdAt).
+   * Returns 0 when the org has no ledger entries yet.
+   */
+  async getBalance(orgId: string): Promise<number> {
+    const [latest] = await db
+      .select({ balanceAfter: photoCreditLedger.balanceAfter })
+      .from(photoCreditLedger)
+      .where(eq(photoCreditLedger.orgId, orgId))
+      .orderBy(desc(photoCreditLedger.createdAt), desc(photoCreditLedger.id))
+      .limit(1);
+
+    return latest?.balanceAfter ?? 0;
+  }
+
+  /**
+   * Record a grant (free credits given by ops, e.g. welcome bonus or
+   * comp for a support escalation). Idempotent on (orgId, refId) only if the
+   * caller passes a refId — otherwise dupes are possible, which is fine for
+   * manual grants.
+   */
+  async recordGrant(input: {
+    orgId: string;
+    userId?: string;
+    amount: number;
+    reason?: string;
+    refId?: string;
+  }): Promise<PhotoCreditLedgerEntry> {
+    if (input.amount <= 0) {
+      throw new Error("Grant amount must be positive");
+    }
+    return this.appendLedgerRow({
+      orgId: input.orgId,
+      userId: input.userId ?? null,
+      delta: input.amount,
+      reason: input.reason ?? "grant",
+      refType: "manual_grant",
+      refId: input.refId ?? null,
+      stripeChargeId: null,
+    });
+  }
+
+  /**
+   * Record a purchase. Called by the Stripe webhook once the Checkout session
+   * completes. Idempotency is enforced by checking for an existing ledger row
+   * with the same stripeChargeId — a retry of the same webhook will no-op
+   * instead of double-granting.
+   */
+  async recordPurchase(input: {
+    orgId: string;
+    userId?: string | null;
+    credits: number;
+    stripeChargeId: string;
+    stripeSessionId: string;
+    packId: string;
+  }): Promise<PhotoCreditLedgerEntry> {
+    if (input.credits <= 0) {
+      throw new Error("Purchase credits must be positive");
+    }
+
+    // Idempotency guard: if this charge was already credited, return the
+    // existing row. Stripe can redeliver the same webhook — we must not
+    // grant twice.
+    const [existing] = await db
+      .select()
+      .from(photoCreditLedger)
+      .where(eq(photoCreditLedger.stripeChargeId, input.stripeChargeId))
+      .limit(1);
+
+    if (existing) {
+      return existing;
+    }
+
+    return this.appendLedgerRow({
+      orgId: input.orgId,
+      userId: input.userId ?? null,
+      delta: input.credits,
+      reason: "purchase",
+      refType: "stripe_checkout",
+      refId: input.stripeSessionId,
+      stripeChargeId: input.stripeChargeId,
+    });
+  }
+
+  /**
+   * Debit for a download. Runs inside a transaction so concurrent downloads
+   * can't both pass the balance check. Throws InsufficientCreditsError on
+   * overdraft — callers should respond 402.
+   *
+   * `amount` is positive; we write it as a negative delta internally.
+   */
+  async chargeForDownload(input: {
+    orgId: string;
+    userId: string;
+    amount: number;
+    refId: string; // photo_download row id (stringified) or version id
+  }): Promise<PhotoCreditLedgerEntry> {
+    if (input.amount <= 0) {
+      throw new Error("Debit amount must be positive");
+    }
+
+    return db.transaction(async (tx) => {
+      // Lock the most recent row for this org so a concurrent debit waits.
+      // SELECT ... FOR UPDATE on a single-row read is the standard pattern.
+      const [latest] = await tx
+        .select({ balanceAfter: photoCreditLedger.balanceAfter })
+        .from(photoCreditLedger)
+        .where(eq(photoCreditLedger.orgId, input.orgId))
+        .orderBy(desc(photoCreditLedger.createdAt), desc(photoCreditLedger.id))
+        .limit(1)
+        .for("update");
+
+      const currentBalance = latest?.balanceAfter ?? 0;
+      if (currentBalance < input.amount) {
+        throw new InsufficientCreditsError(input.orgId, input.amount, currentBalance);
+      }
+
+      const newBalance = currentBalance - input.amount;
+      const [row] = await tx
+        .insert(photoCreditLedger)
+        .values({
+          orgId: input.orgId,
+          userId: input.userId,
+          delta: -input.amount,
+          balanceAfter: newBalance,
+          reason: "download",
+          refType: "photo_download",
+          refId: input.refId,
+          stripeChargeId: null,
+        })
+        .returning();
+
+      return row;
+    });
+  }
+
+  /**
+   * Refund previously-debited credits. Used when a download fails after
+   * debit (rare — we debit post-auth and pre-serve) or an ops correction.
+   */
+  async recordRefund(input: {
+    orgId: string;
+    userId?: string | null;
+    amount: number;
+    reason?: string;
+    refId?: string;
+  }): Promise<PhotoCreditLedgerEntry> {
+    if (input.amount <= 0) {
+      throw new Error("Refund amount must be positive");
+    }
+    return this.appendLedgerRow({
+      orgId: input.orgId,
+      userId: input.userId ?? null,
+      delta: input.amount,
+      reason: input.reason ?? "refund",
+      refType: "manual_refund",
+      refId: input.refId ?? null,
+      stripeChargeId: null,
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Stripe Checkout bridge
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Create a Stripe Checkout session for a credit pack. Returns the session
+   * URL the client should redirect to. Metadata embeds orgId + userId +
+   * packId so the webhook has everything it needs to grant correctly
+   * without another DB lookup by email/customer.
+   */
+  async createCheckoutSession(input: {
+    orgId: string;
+    userId: string;
+    userEmail: string;
+    packId: PhotoCreditPack["id"];
+    successUrl: string;
+    cancelUrl: string;
+  }): Promise<{ sessionId: string; url: string }> {
+    const pack = getPhotoCreditPacks().find((p) => p.id === input.packId);
+    if (!pack) {
+      throw new Error(`Unknown pack id: ${input.packId}`);
+    }
+    if (!pack.priceId) {
+      throw new PackNotConfiguredError(input.packId);
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      payment_method_types: ["card"],
+      line_items: [
+        {
+          price: pack.priceId,
+          quantity: 1,
+        },
+      ],
+      customer_email: input.userEmail,
+      // Metadata carries org + user + pack through to the webhook. We use
+      // metadata (not client_reference_id) so we can pass multiple fields.
+      metadata: {
+        orgId: input.orgId,
+        userId: input.userId,
+        packId: pack.id,
+        credits: String(pack.credits),
+        source: "photo_credit_pack",
+      },
+      // payment_intent metadata is duplicated so we can find the intent
+      // from a charge webhook even if Stripe drops the session context.
+      payment_intent_data: {
+        metadata: {
+          orgId: input.orgId,
+          userId: input.userId,
+          packId: pack.id,
+          credits: String(pack.credits),
+          source: "photo_credit_pack",
+        },
+      },
+      success_url: input.successUrl,
+      cancel_url: input.cancelUrl,
+    });
+
+    if (!session.url) {
+      throw new Error("Stripe did not return a checkout session URL");
+    }
+
+    return { sessionId: session.id, url: session.url };
+  }
+
+  /**
+   * Handle a Stripe webhook event for the photo module. Returns `true` if
+   * the event was recognised as photo-related (and handled), `false`
+   * otherwise so the caller can forward it to other handlers.
+   *
+   * Events we care about:
+   *   - `checkout.session.completed` (mode=payment, metadata.source=photo_credit_pack)
+   */
+  async handleWebhookEvent(event: Stripe.Event): Promise<boolean> {
+    if (event.type !== "checkout.session.completed") {
+      return false;
+    }
+
+    const session = event.data.object as Stripe.Checkout.Session;
+
+    // Only act on payment-mode sessions flagged as photo credit packs.
+    // Subscription-mode sessions (from the ad-generator) flow through
+    // subscription-service and must not be touched here.
+    if (session.mode !== "payment") return false;
+    if (session.metadata?.source !== "photo_credit_pack") return false;
+
+    if (session.payment_status !== "paid") {
+      console.warn(
+        `PHOTO_CREDITS: skipping session ${session.id} — payment_status=${session.payment_status}`
+      );
+      return true; // recognised but not actionable yet
+    }
+
+    const orgId = session.metadata.orgId;
+    const userId = session.metadata.userId;
+    const packId = session.metadata.packId;
+    if (!orgId || !packId) {
+      console.error(
+        `PHOTO_CREDITS: session ${session.id} missing metadata — cannot credit`
+      );
+      return true;
+    }
+
+    // Trust the priceId on the session, not the metadata.credits value.
+    // metadata is user-controlled (via our own code), but the priceId is
+    // Stripe-authoritative — if someone tampered with metadata we'd catch it.
+    const lineItems = await stripe.checkout.sessions.listLineItems(session.id, {
+      limit: 5,
+    });
+    const lineItem = lineItems.data[0];
+    const priceId = lineItem?.price?.id ?? "";
+    const pack = resolvePackByPriceId(priceId);
+
+    if (!pack) {
+      console.error(
+        `PHOTO_CREDITS: session ${session.id} priceId=${priceId} not in catalog — skipping`
+      );
+      return true;
+    }
+
+    const chargeId =
+      typeof session.payment_intent === "string"
+        ? session.payment_intent
+        : session.payment_intent?.id;
+
+    if (!chargeId) {
+      console.error(`PHOTO_CREDITS: session ${session.id} has no payment_intent`);
+      return true;
+    }
+
+    const row = await this.recordPurchase({
+      orgId,
+      userId,
+      credits: pack.credits,
+      stripeChargeId: chargeId,
+      stripeSessionId: session.id,
+      packId: pack.id,
+    });
+
+    console.log(
+      `💳 PHOTO_CREDITS: granted ${pack.credits} to org=${orgId} (session=${session.id}, ledger=${row.id}, balanceAfter=${row.balanceAfter})`
+    );
+    return true;
+  }
+
+  /**
+   * Recent ledger entries for an org, newest first. Used by the UI
+   * transactions panel and by ops when investigating balance disputes.
+   */
+  async listRecent(orgId: string, limit = 50): Promise<PhotoCreditLedgerEntry[]> {
+    return db
+      .select()
+      .from(photoCreditLedger)
+      .where(eq(photoCreditLedger.orgId, orgId))
+      .orderBy(desc(photoCreditLedger.createdAt), desc(photoCreditLedger.id))
+      .limit(limit);
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Internals
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Append a non-debit ledger row. Debits MUST go through
+   * `chargeForDownload` so the locking semantics are right. This helper is
+   * for grants/purchases/refunds where concurrency doesn't matter (delta
+   * is always additive to balance).
+   */
+  private async appendLedgerRow(input: {
+    orgId: string;
+    userId: string | null;
+    delta: number;
+    reason: string;
+    refType: string | null;
+    refId: string | null;
+    stripeChargeId: string | null;
+  }): Promise<PhotoCreditLedgerEntry> {
+    return db.transaction(async (tx) => {
+      const [latest] = await tx
+        .select({ balanceAfter: photoCreditLedger.balanceAfter })
+        .from(photoCreditLedger)
+        .where(eq(photoCreditLedger.orgId, input.orgId))
+        .orderBy(desc(photoCreditLedger.createdAt), desc(photoCreditLedger.id))
+        .limit(1)
+        .for("update");
+
+      const currentBalance = latest?.balanceAfter ?? 0;
+      const newBalance = currentBalance + input.delta;
+
+      const [row] = await tx
+        .insert(photoCreditLedger)
+        .values({
+          orgId: input.orgId,
+          userId: input.userId,
+          delta: input.delta,
+          balanceAfter: newBalance,
+          reason: input.reason,
+          refType: input.refType,
+          refId: input.refId,
+          stripeChargeId: input.stripeChargeId,
+        })
+        .returning();
+      return row;
+    });
+  }
+}
+
+export const photoCreditService = new PhotoCreditService();

--- a/server/services/subscription-service.ts
+++ b/server/services/subscription-service.ts
@@ -197,6 +197,19 @@ class SubscriptionService {
   async handleWebhook(signature: string, body: Buffer): Promise<void> {
     const event = stripe.webhooks.constructEvent(body, signature, ENV.stripe.webhookSecret);
 
+    // Photo module's one-time credit pack purchases ride the same webhook
+    // endpoint. Delegate FIRST so photo events never accidentally touch the
+    // subscription handler below — the photo service returns `true` when it
+    // handled the event, `false` otherwise (meaning it's not a photo event).
+    try {
+      const { photoCreditService } = await import('./photo-credit-service');
+      const handled = await photoCreditService.handleWebhookEvent(event);
+      if (handled) return;
+    } catch (err) {
+      console.error('❌ Photo credit webhook handler failed:', err);
+      throw err; // let the outer webhook return 400 so Stripe retries
+    }
+
     switch (event.type) {
       case 'customer.subscription.created':
       case 'customer.subscription.updated': {


### PR DESCRIPTION
Backend
- photo-credit-service: append-only ledger backed by photo_credit_ledger
  * getBalance — O(1) read from latest row's balanceAfter
  * chargeForDownload — transactional debit with SELECT FOR UPDATE to prevent concurrent overdraft
  * recordPurchase — idempotent on stripe_charge_id (Stripe retries won't double-grant)
  * recordGrant / recordRefund for ops corrections
  * createCheckoutSession — one-time mode=payment (not subscription), metadata carries orgId/userId/packId to the webhook
  * handleWebhookEvent — verifies priceId against catalog before granting, so tampered metadata can't inflate credits
- subscription-service webhook delegates photo events first; returns early if photo service claims the event, otherwise falls through to subscription handling
- environment.ts: 3 new photo pack price IDs (test + live variants); empty values are filtered out of the UI so no broken buy buttons
- routes: GET /credits/packs, GET /credits/balance, GET /credits/ledger, POST /credits/checkout

Frontend
- CreditsChip component: balance pill tinted by state (green/amber/red), "Buy credits" button opens BuyCreditsModal with 3-pack picker → Stripe Checkout redirect
- Mounted in both /photos and /photos/:id headers
- Post-checkout redirect handler invalidates balance at 1.5s + 5s to catch slow webhook delivery without blocking first paint

Packs (display pricing, Stripe is authoritative)
- Starter:  $49  / 100   credits  (~$0.49/credit)
- Growth:  $199  / 500   credits  (~$0.40/credit)
- Agency:  $699  / 2000  credits  (~$0.35/credit)