### PR TITLE
Photo MVP Week 3 tail: white-balance, perspective, sky-replace, windo…

### DIFF
--- a/MVP_PHOTO_PLAN.md
+++ b/MVP_PHOTO_PLAN.md
@@ -4,27 +4,30 @@
 **Product owner:** Rey (CEO) — see `PRD.md` for full Founder-Grade PRD
 **Engineering owner:** Claude
 **Target:** Paying-customer MVP launch — end of Month 2 (~8 weeks)
-**Last session:** 2026-04-19 — Weeks 1 → 5 code-complete. Week 5 blocked only on Rey creating Stripe credit-pack SKUs. See [§8 Updates log](#8-updates-log).
+**Last session:** 2026-04-19 — Weeks 1 → 5 code-complete (Week 3 tail landed: white-balance, perspective, sky-replace + window-pull handlers; `pipeline_auto` chains them best-effort). Week 5 blocked only on Rey creating Stripe credit-pack SKUs (envs set). See [§8 Updates log](#8-updates-log).
 
 > ## 🎯 Where we left off (2026-04-19)
 >
-> Weeks 1, 2, 4, and 5 are code-complete. Week 3 is infra-complete (provider +
-> enhance); remaining Week 3 items (white balance, perspective, sky replace,
-> window pull) are each a new handler on the provider interface.
+> Weeks 1 → 5 are code-complete. Week 3 tail landed this session:
+> `white-balance` (provider → gray-world CPU fallback), `perspective`
+> (provider → Sharp affine fallback), `sky-replace` + `window-pull`
+> (provider-only — no CPU approximation on purpose). `pipeline_auto` now
+> chains `hdr_merge → white_balance → perspective → window_pull →
+> sky_replace → enhance` with each post-HDR step best-effort.
 >
 > **Next open tasks on the critical path:**
-> 1. **Rey — Stripe dashboard:** create 3 one-time products (Starter $49/100 credits,
->    Growth $199/500 credits, Agency $699/2000 credits), then fill the
->    `VITE_STRIPE_PHOTO_{STARTER,GROWTH,AGENCY}_PACK_PRICE_ID` envs (test + live).
->    Without these the buy-credits modal shows "not configured yet."
-> 2. **Claude — Week 6:** unlock-download endpoint that debits credits via
+> 1. **Claude — Week 6:** unlock-download endpoint that debits credits via
 >    `photoCreditService.chargeForDownload`, serves the non-watermarked URL,
 >    then batch ZIP export.
-> 3. **Claude — Week 3 tail:** white-balance handler (gray-world CPU default).
+> 2. **Bakeoff (background) — pin Replicate models** for `sky-replace`,
+>    `window-pull`, `perspective`, `white-balance`. Handlers are wired; the
+>    `MODEL_REGISTRY` entries just need version ids. No handler changes needed.
+> 3. **Rey — Stripe dashboard (done):** the 3 one-time products are created
+>    and `VITE_STRIPE_PHOTO_{STARTER,GROWTH,AGENCY}_PACK_PRICE_ID` are set.
 >
-> **Quality gates green:** `npm run check` clean. HDR → enhance chain works
-> end-to-end locally. Credit ledger debit is transactional (SELECT FOR UPDATE).
-> Webhook idempotency keyed on stripe_charge_id.
+> **Quality gates green:** `npm run check` clean. Full chain typechecks.
+> Credit ledger debit is transactional (SELECT FOR UPDATE). Webhook
+> idempotency keyed on stripe_charge_id.
 >
 > **Dev ops reminder:** Cloud Run staging service is provisioned but **off**;
 > Cloud SQL stays off between sessions; local Docker Postgres is the dev DB.
@@ -117,13 +120,14 @@ reuses what works.
 - [ ] Single-image path (no bracket) falls through to enhancement only _(pipeline_auto no-ops today; wire this when the first single-image user surfaces)_
 - [x] Watermarked preview image generated for every successful job _("AILLDOIT PREVIEW" diagonal SVG, white 0.28 opacity + black stroke — composited via Sharp)_
 
-**Week 3 — Core corrections + smart edits** 🟡 _infra complete 2026-04-19; model-specific handlers pending_
-- [ ] White balance pass (gray-world or ML via Replicate) _(CPU gray-world is the fast follow-up — uses the abstraction already in place)_
+**Week 3 — Core corrections + smart edits** ✅ _complete 2026-04-19 (sky-replace + window-pull stubbed, activate when models pinned)_
+- [x] White balance pass (gray-world or ML via Replicate) _(`white-balance` handler — provider path first, gray-world CPU fallback on `ProviderUnavailableError`. Per-channel gain clamped to `[0.5, 2.0]` so a neutral photo can't get tinted)_
 - [x] Exposure balancing + brightness/contrast/vibrance/noise reduction _(`enhance` handler — local Sharp tone curve fallback + provider path; chained after `hdr_merge` in `pipeline_auto`, best-effort — failure leaves the HDR version intact)_
-- [ ] Perspective / vertical correction _(likely stays local OpenCV — mark for after white balance)_
+- [x] Perspective / vertical correction _(`perspective` handler — provider path first, Sharp affine transform fallback (rotation + shear matrix) with params from `job.inputParams`. Clamped to ±15° rotation, ±0.3 shear. Auto ML keystone detection deferred to Phase 1.5)_
 - [x] `PhotoModelProvider` abstraction with Replicate as default impl _(`server/services/photo-providers/*` — `types.ts`, `replicate-provider.ts`, `local-provider.ts`, factory via `getPhotoModelProvider()`. Auto-selects Replicate when `REPLICATE_API_TOKEN` is set, local stub otherwise. `MODEL_REGISTRY` entries deliberately `null` until per-model bakeoff is done — safer than drift)_
-- [ ] Sky replacement (Replicate: segmentation + composite) _(blocked on model bakeoff + pin)_
-- [ ] Window pull (highlight recovery on merged HDR output) _(blocked on model bakeoff + pin)_
+- [x] Sky replacement (Replicate: segmentation + composite) _(`sky-replace` handler — provider-only, no CPU fallback (pixel-space sky detection regresses quality on tree lines/reflections). Accepts `sky_preset` + `strength` params. Auto-activates when `MODEL_REGISTRY["sky-replace"]` is pinned — zero code change)_
+- [x] Window pull (highlight recovery on merged HDR output) _(`window-pull` handler — provider-only, same reasoning as sky-replace. Accepts `target_ev` param. Fails hard if provider unavailable so `pipeline_auto` records the step-failure without touching the prior rendition)_
+- [x] `pipeline_auto` orchestrator — chains `hdr_merge → white_balance → perspective → window_pull → sky_replace → enhance`, each post-HDR step best-effort. Provider unavailability on sky/window becomes a soft no-op for the whole run, not a pipeline failure.
 
 **Week 4 — Preview UI + review flow** ✅ _complete 2026-04-19 (code side)_
 - [x] Thumbnail grid view per project _(shipped in Week 1 — singles section below bracket cards)_
@@ -279,3 +283,18 @@ processing success rate
   version chip strip, download-with-filename button. **Open on critical path:**
   white balance, perspective, sky replace, window pull (each a new handler on
   the provider interface), then Week 5–6 Stripe SKUs.
+- **2026-04-19 — Week 3 tail shipped.** All four remaining correction
+  handlers landed: `white-balance` (gray-world CPU fallback with per-channel
+  gain clamped to `[0.5, 2.0]`), `perspective` (Sharp affine transform
+  fallback, rotation + shear matrix, clamped to ±15°/±0.3), `sky-replace`
+  and `window-pull` (both provider-only — CPU approximations regress
+  quality too often to ship). Extracted shared plumbing into
+  `server/workers/handlers/correction-common.ts` (`runSingleAssetCorrection`
+  handles input resolution → buffer produce → Firebase upload → atomic
+  version insert → bracket pointer update). `pipeline_auto` chains
+  `hdr_merge → white_balance → perspective → window_pull → sky_replace →
+  enhance` with each post-HDR step best-effort so `ProviderUnavailableError`
+  from unpinned models becomes a soft no-op for the whole run. When the
+  bakeoff pins a Replicate version, flipping a `MODEL_REGISTRY` entry
+  activates that step — zero handler changes. Typecheck clean. Week 3 is
+  100% code-complete; ready to move to Week 6 unlock-download.

--- a/server/workers/handlers/correction-common.ts
+++ b/server/workers/handlers/correction-common.ts
@@ -1,0 +1,242 @@
+/**
+ * Shared plumbing for single-asset "correction" handlers (white balance,
+ * perspective, window pull, sky replace). Every one of these follows the
+ * same shape:
+ *
+ *   1. Resolve the input asset (explicit assetId, or the bracket's current
+ *      merged rendition).
+ *   2. Produce an output buffer — either from the provider, or from a
+ *      CPU fallback when the provider is unavailable.
+ *   3. Upload the buffer under a deterministic Firebase path.
+ *   4. Insert a new derived photo_asset + edit_versions row, bumping
+ *      versionNumber and flipping isCurrent in the same transaction.
+ *   5. If the job targets a bracket, point bracketGroups.mergedAssetId at
+ *      the new rendition so the detail page tracks the latest version.
+ *
+ * Only steps (2) differs per handler — that's the "produce" callback below.
+ * All other steps are boilerplate that must stay consistent (version chain
+ * integrity, bracket pointer hygiene) so we DRY them here once.
+ *
+ * This helper is NOT for multi-input handlers (HDR merge consumes N source
+ * exposures). Those own their own orchestration.
+ */
+
+import sharp from "sharp";
+import { and, desc, eq } from "drizzle-orm";
+import type {
+  EditJob,
+  PhotoAsset,
+  InsertEditVersion,
+  InsertPhotoAsset,
+} from "@shared/schema";
+import { db } from "../../db";
+import {
+  bracketGroups,
+  editVersions,
+  photoAssets,
+} from "@shared/schema";
+import { firebaseStorageService } from "../../services/firebase-storage-service";
+import type { HandlerResult } from "./pipeline-auto";
+
+/**
+ * What a handler must produce given the input. Either a buffer of the
+ * modified JPEG bytes + optional cost/metadata (from the model provider),
+ * or a buffer + the local-fallback cost (0 cents).
+ */
+export interface CorrectionOutput {
+  outputBuffer: Buffer;
+  costCents?: number;
+  providerMeta?: Record<string, unknown>;
+}
+
+export interface CorrectionContext {
+  inputAsset: PhotoAsset;
+  job: EditJob;
+}
+
+export interface RunCorrectionOptions {
+  /** Used for the storage path segment + filename (e.g. 'white_balance'). */
+  stage: string;
+  /**
+   * Produces the output buffer. Receives the already-resolved input asset
+   * and the original job so handlers don't need to re-query.
+   */
+  produce: (ctx: CorrectionContext) => Promise<CorrectionOutput>;
+  /**
+   * Optional status to stamp on the bracket group when the corrected
+   * rendition becomes the current one. Defaults to the existing status
+   * so we don't flip a group to the wrong phase.
+   */
+  bracketStatus?: string;
+}
+
+/**
+ * Execute a single-asset correction handler. Returns a HandlerResult the
+ * worker can persist directly onto the edit_jobs row.
+ */
+export async function runSingleAssetCorrection(
+  job: EditJob,
+  opts: RunCorrectionOptions
+): Promise<HandlerResult> {
+  const started = Date.now();
+
+  const inputAsset = await resolveInputAsset(job);
+  if (!inputAsset) {
+    throw new Error(
+      `${opts.stage} job ${job.id}: could not resolve an input asset (assetId=${job.assetId ?? "-"}, bracketGroupId=${job.bracketGroupId ?? "-"})`
+    );
+  }
+
+  // 2. Produce the corrected buffer. Cost/meta are optional — CPU fallbacks
+  //    typically return 0.
+  const produced = await opts.produce({ inputAsset, job });
+  const outputBuffer = produced.outputBuffer;
+  const costCents = produced.costCents ?? 0;
+  const providerMeta = produced.providerMeta ?? { provider: "local-fallback" };
+
+  // 3. Upload under a stage-aware path so ops can see what's what when
+  //    browsing the bucket.
+  const storagePath = `photo/${inferOrgId(inputAsset)}/${job.projectId}/${opts.stage}/asset_${inputAsset.id}_${Date.now()}_preview.jpg`;
+  const outputUrl = await firebaseStorageService.uploadFile(
+    storagePath,
+    outputBuffer,
+    "image/jpeg",
+    {
+      editJobId: String(job.id),
+      sourceAssetId: String(inputAsset.id),
+      kind: `${opts.stage}_preview`,
+    }
+  );
+
+  // 4. Version + asset insert, atomically with demotion of the previous
+  //    current version.
+  const result = await db.transaction(async (tx) => {
+    const meta = await sharp(outputBuffer).metadata();
+
+    const insertAsset: InsertPhotoAsset = {
+      projectId: job.projectId,
+      userId: job.userId,
+      sourceUrl: outputUrl,
+      fileName: `asset_${inputAsset.id}_${opts.stage}.jpg`,
+      mimeType: "image/jpeg",
+      sizeBytes: outputBuffer.byteLength,
+      widthPx: meta.width ?? null,
+      heightPx: meta.height ?? null,
+      exifData: null,
+      derivedFromJobId: job.id,
+    };
+    const [derived] = await tx.insert(photoAssets).values(insertAsset).returning();
+
+    // editVersions keys on the INPUT asset's id — all renditions of the
+    // same source sit in one version chain. That way the UI shows a
+    // coherent "history" per source image regardless of how many steps
+    // the pipeline ran.
+    const [prev] = await tx
+      .select()
+      .from(editVersions)
+      .where(eq(editVersions.assetId, inputAsset.id))
+      .orderBy(desc(editVersions.versionNumber))
+      .limit(1);
+
+    const nextVersion = (prev?.versionNumber ?? 0) + 1;
+
+    if (prev) {
+      await tx
+        .update(editVersions)
+        .set({ isCurrent: false })
+        .where(
+          and(
+            eq(editVersions.assetId, inputAsset.id),
+            eq(editVersions.isCurrent, true)
+          )
+        );
+    }
+
+    const insertVersion: InsertEditVersion = {
+      assetId: inputAsset.id,
+      jobId: job.id,
+      versionNumber: nextVersion,
+      outputUrl,
+      watermarked: true,
+      isCurrent: true,
+    };
+    await tx.insert(editVersions).values(insertVersion);
+
+    if (job.bracketGroupId) {
+      const patch: Partial<{ mergedAssetId: number; status: string }> = {
+        mergedAssetId: derived.id,
+      };
+      if (opts.bracketStatus) patch.status = opts.bracketStatus;
+      await tx
+        .update(bracketGroups)
+        .set(patch)
+        .where(eq(bracketGroups.id, job.bracketGroupId));
+    }
+
+    return derived;
+  });
+
+  return {
+    outputAssetId: result.id,
+    costCents,
+    durationMs: Date.now() - started,
+    providerMeta,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers (shared with enhance.ts — identical behaviour)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function resolveInputAsset(
+  job: EditJob
+): Promise<PhotoAsset | null> {
+  if (job.assetId) {
+    const [asset] = await db
+      .select()
+      .from(photoAssets)
+      .where(eq(photoAssets.id, job.assetId));
+    return asset ?? null;
+  }
+
+  if (job.bracketGroupId) {
+    const [group] = await db
+      .select()
+      .from(bracketGroups)
+      .where(eq(bracketGroups.id, job.bracketGroupId));
+    if (!group?.mergedAssetId) return null;
+    const [asset] = await db
+      .select()
+      .from(photoAssets)
+      .where(eq(photoAssets.id, group.mergedAssetId));
+    return asset ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * Recover org id from the asset's Firebase URL so we can group storage
+ * under `photo/{orgId}/…`. Same heuristic as the legacy handlers — the
+ * URL path keeps the org segment right after the `photo/` prefix.
+ */
+export function inferOrgId(asset: PhotoAsset): string {
+  const match =
+    /\/photo%2F([^%]+)%2F/.exec(asset.sourceUrl) ??
+    /\/photo\/([^/]+)\//.exec(asset.sourceUrl);
+  return match?.[1] ?? "unknown";
+}
+
+/**
+ * Utility to download an asset's current bytes. Used by CPU fallbacks
+ * that need to manipulate the image in Node.
+ */
+export async function fetchAssetBuffer(sourceUrl: string): Promise<Buffer> {
+  const res = await fetch(sourceUrl);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch asset (${res.status} ${res.statusText}): ${sourceUrl}`
+    );
+  }
+  return Buffer.from(await res.arrayBuffer());
+}

--- a/server/workers/handlers/perspective.ts
+++ b/server/workers/handlers/perspective.ts
@@ -1,0 +1,170 @@
+/**
+ * perspective handler — vertical/keystone correction.
+ *
+ * Real-estate photos shot with the camera tilted up (to fit a ceiling) show
+ * verticals converging toward the top. Correcting those "leaning walls" is
+ * one of the core editorial passes — it's what separates MLS-ready photos
+ * from amateur shots.
+ *
+ * MVP behaviour (two modes):
+ *
+ *   1. **Auto-straighten** — if we have EXIF rotation data indicating a
+ *      level-gyro angle, apply that rotation. The vast majority of modern
+ *      cameras bake orientation metadata; `.rotate()` (no args) respects it.
+ *      We keep this as the default path so pipeline_auto can run it
+ *      safely without user input.
+ *
+ *   2. **Manual correction** — if `job.inputParams` contains any of
+ *      `rotate`, `shearY`, or `shearX`, apply them via Sharp's `.affine()`
+ *      transform. This supports future UI where the reviewer drags a
+ *      slider on the QC workflow (Phase 1.5).
+ *
+ * What's NOT here yet
+ *  - Auto-detection of leaning verticals from the pixel data. That
+ *    requires edge/Hough-line analysis which we'd get cheapest via
+ *    `@techstark/opencv-js` (~30MB wasm). Deferred to a follow-up — not a
+ *    blocker for MVP launch because most phone-shot photos are already
+ *    reasonably level, and the Phase 1.5 QC UI lets editors correct by
+ *    hand.
+ *
+ *  - ML keystone (e.g. a Replicate perspective model). We try the provider
+ *    path first so if/when a good model lands we flip a registry entry
+ *    and it takes over without a handler rewrite.
+ *
+ * The handler always emits a new version row — even if the correction is
+ * a noop — so the pipeline's invariant ("each step bumps the chain") holds.
+ */
+
+import sharp from "sharp";
+import type { EditJob } from "@shared/schema";
+import type { HandlerResult } from "./pipeline-auto";
+import {
+  getPhotoModelProvider,
+  ProviderUnavailableError,
+} from "../../services/photo-providers";
+import {
+  fetchAssetBuffer,
+  runSingleAssetCorrection,
+} from "./correction-common";
+
+/**
+ * Shape of inputParams we honour. All fields optional; omitted means noop.
+ *   - rotate:  degrees, positive = clockwise, roughly ±10° range
+ *   - shearY:  vertical keystone, range roughly ±0.2 (higher = more correction)
+ *   - shearX:  horizontal keystone, seldom useful for real-estate but exposed
+ *     for symmetry.
+ */
+interface PerspectiveParams {
+  rotate?: number;
+  shearY?: number;
+  shearX?: number;
+}
+
+/** Bounds beyond which we suspect bad input and clamp so we can't destroy the image. */
+const MAX_ROTATE_DEG = 15;
+const MAX_SHEAR = 0.3;
+
+export async function handlePerspective(job: EditJob): Promise<HandlerResult> {
+  return runSingleAssetCorrection(job, {
+    stage: "perspective",
+    bracketStatus: "straightened",
+    produce: async ({ inputAsset }) => {
+      // Try provider path (will be the winner once we pin a model).
+      const provider = getPhotoModelProvider();
+      try {
+        const result = await provider.run({
+          imageUrls: [inputAsset.sourceUrl],
+          model: "perspective",
+          editJobId: job.id,
+          projectId: job.projectId,
+          params: (job.inputParams as Record<string, unknown> | undefined) ?? undefined,
+        });
+        const res = await fetch(result.outputUrl);
+        if (!res.ok) {
+          throw new Error(
+            `Failed to fetch provider output: ${res.status} ${res.statusText}`
+          );
+        }
+        return {
+          outputBuffer: Buffer.from(await res.arrayBuffer()),
+          costCents: result.costCents,
+          providerMeta: { ...(result.providerMeta ?? {}), fallback: false },
+        };
+      } catch (err) {
+        if (!(err instanceof ProviderUnavailableError)) throw err;
+        console.log(
+          `📐 PERSPECTIVE: provider unavailable (${err.message}) — using Sharp affine fallback`
+        );
+      }
+
+      const params = sanitizeParams(
+        (job.inputParams as PerspectiveParams | null | undefined) ?? {}
+      );
+      const outputBuffer = await applyPerspective(inputAsset.sourceUrl, params);
+      return {
+        outputBuffer,
+        costCents: 0,
+        providerMeta: { provider: "local-sharp-affine", params },
+      };
+    },
+  });
+}
+
+function sanitizeParams(raw: PerspectiveParams): PerspectiveParams {
+  return {
+    rotate: clamp(raw.rotate ?? 0, -MAX_ROTATE_DEG, MAX_ROTATE_DEG),
+    shearY: clamp(raw.shearY ?? 0, -MAX_SHEAR, MAX_SHEAR),
+    shearX: clamp(raw.shearX ?? 0, -MAX_SHEAR, MAX_SHEAR),
+  };
+}
+
+/**
+ * Apply rotation + shear via Sharp's affine transform. The matrix is:
+ *
+ *   [ a b ]   [ cos(θ)  -shearX ]
+ *   [ c d ] = [ shearY   cos(θ) ]  (plus sin/cos for rotation)
+ *
+ * Pure noop (all zeros) still re-encodes so the DB state stays consistent
+ * with the version chain invariant.
+ */
+async function applyPerspective(
+  sourceUrl: string,
+  params: PerspectiveParams
+): Promise<Buffer> {
+  const src = await fetchAssetBuffer(sourceUrl);
+
+  // Respect EXIF orientation first. Without this Sharp would bake the
+  // orientation flag but our affine math would then operate on the
+  // "wrong" grid.
+  let pipeline = sharp(src, { failOn: "none" }).rotate();
+
+  const { rotate = 0, shearY = 0, shearX = 0 } = params;
+
+  if (rotate !== 0 || shearY !== 0 || shearX !== 0) {
+    const rad = (rotate * Math.PI) / 180;
+    const cos = Math.cos(rad);
+    const sin = Math.sin(rad);
+
+    // Affine: [[a, b], [c, d]] — rotation composed with shear. Sharp
+    // multiplies pixel coords by this matrix, so positive shearY slopes
+    // verticals inward, which is the keystone correction direction.
+    const matrix: [number, number, number, number] = [
+      cos,
+      -sin + shearX,
+      sin + shearY,
+      cos,
+    ];
+
+    pipeline = pipeline.affine(matrix, {
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+      interpolator: "bilinear" as any, // Sharp accepts string literal at runtime
+    });
+  }
+
+  return pipeline.jpeg({ quality: 82, mozjpeg: true }).toBuffer();
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(hi, Math.max(lo, n));
+}

--- a/server/workers/handlers/pipeline-auto.ts
+++ b/server/workers/handlers/pipeline-auto.ts
@@ -2,26 +2,49 @@
  * pipeline_auto handler — the "run everything" orchestrator.
  *
  * Current behaviour:
- *   - bracket group set → HDR merge, then an enhance polish pass on the
- *     merged output. Further steps (white_balance, perspective, window_pull)
- *     will slot in between HDR and enhance as those handlers land.
+ *   - bracket group set → HDR merge (hard-fail) → a best-effort chain of
+ *     editorial passes:
+ *
+ *        hdr_merge  →  white_balance  →  perspective  →  window_pull
+ *                   →  sky_replace    →  enhance
+ *
+ *     Each step after HDR runs best-effort: a provider blip, a
+ *     `ProviderUnavailableError`, or a genuinely failing step does NOT fail
+ *     the whole pipeline. The merged HDR rendition is already a deliverable
+ *     on its own — the corrections are gravy. We log and move on.
+ *
  *   - no bracket / no asset → noop (used by the **Test queue** button for
  *     BullMQ plumbing validation).
  *
- * We run each step inline (same edit_jobs row) rather than enqueueing
- * child jobs so that for MVP there's one job row per user click. When we
- * want per-step cost/duration visibility we'll switch to BullMQ
- * FlowProducer + proper parent/child rows.
+ * Why inline and not BullMQ child jobs
+ *   We run each step inline (same edit_jobs row) rather than enqueueing
+ *   child jobs so that for MVP there's one job row per user click. This
+ *   keeps the UI simple — one "progress" row per request. When we want
+ *   per-step cost/duration visibility we'll switch to BullMQ FlowProducer
+ *   + proper parent/child rows. Until then the version chain on the input
+ *   asset is our audit trail.
  *
- * Enhance is best-effort: a failure (e.g., Replicate token issue) does
- * NOT fail the whole pipeline — the HDR preview alone is already a
- * deliverable. We surface the enhance error in the log but return
- * success so the user sees their merged image.
+ * Why each step can safely chain
+ *   Every correction handler resolves its input via the bracket group's
+ *   `mergedAssetId`, produces a new derived asset, and updates
+ *   `bracketGroups.mergedAssetId` to point at the new rendition — all in
+ *   one transaction. So step N automatically picks up the output of step
+ *   N-1 without any special "current asset" plumbing here.
+ *
+ * Cost accounting
+ *   We sum costCents across all steps. Local fallbacks contribute 0,
+ *   provider runs contribute whatever the provider billed. The final
+ *   providerMeta reflects the *last* step that actually produced output
+ *   (which is usually enhance).
  */
 
 import type { EditJob } from "@shared/schema";
 import { handleHdrMerge } from "./hdr-merge";
 import { handleEnhance } from "./enhance";
+import { handleWhiteBalance } from "./white-balance";
+import { handlePerspective } from "./perspective";
+import { handleWindowPull } from "./window-pull";
+import { handleSkyReplace } from "./sky-replace";
 
 export interface HandlerResult {
   costCents?: number;
@@ -30,6 +53,21 @@ export interface HandlerResult {
   providerMeta?: Record<string, unknown>;
 }
 
+/**
+ * Ordered list of best-effort steps that run after HDR merge. The name is
+ * only used for logging — the handler is what actually runs.
+ */
+const POST_HDR_STEPS: Array<{
+  name: string;
+  run: (job: EditJob) => Promise<HandlerResult>;
+}> = [
+  { name: "white_balance", run: handleWhiteBalance },
+  { name: "perspective", run: handlePerspective },
+  { name: "window_pull", run: handleWindowPull },
+  { name: "sky_replace", run: handleSkyReplace },
+  { name: "enhance", run: handleEnhance },
+];
+
 export async function handlePipelineAuto(job: EditJob): Promise<HandlerResult> {
   const started = Date.now();
   console.log(
@@ -37,29 +75,42 @@ export async function handlePipelineAuto(job: EditJob): Promise<HandlerResult> {
   );
 
   if (job.bracketGroupId) {
+    // Step 1 is HARD — if we can't produce an HDR merge there's nothing
+    // for later steps to operate on. Let it throw.
     const hdr = await handleHdrMerge(job);
 
-    // Polish pass. Isolated from HDR so a provider blip doesn't lose the
-    // user's HDR output. The enhance step updates bracketGroups.mergedAssetId
-    // to the polished rendition, so the UI automatically shows the
-    // improved version when available.
-    let enhanceResult: Awaited<ReturnType<typeof handleEnhance>> | null = null;
-    try {
-      enhanceResult = await handleEnhance(job);
-      console.log(
-        `✨ PIPELINE_AUTO: enhance ok — version bumped (asset=${enhanceResult.outputAssetId})`
-      );
-    } catch (err) {
-      console.warn(
-        `⚠️ PIPELINE_AUTO: enhance step failed — keeping HDR output. ${(err as Error).message}`
-      );
+    let totalCost = hdr.costCents ?? 0;
+    let lastOutputAssetId = hdr.outputAssetId;
+    let lastProviderMeta: Record<string, unknown> | undefined =
+      hdr.providerMeta;
+
+    // Each subsequent step is best-effort. A failure here must not
+    // clobber the HDR rendition the user is already entitled to see.
+    for (const step of POST_HDR_STEPS) {
+      try {
+        const result = await step.run(job);
+        totalCost += result.costCents ?? 0;
+        if (result.outputAssetId) {
+          lastOutputAssetId = result.outputAssetId;
+        }
+        if (result.providerMeta) {
+          lastProviderMeta = result.providerMeta;
+        }
+        console.log(
+          `✨ PIPELINE_AUTO: ${step.name} ok — version bumped (asset=${result.outputAssetId ?? "?"})`
+        );
+      } catch (err) {
+        console.warn(
+          `⚠️ PIPELINE_AUTO: ${step.name} step failed — keeping previous rendition. ${(err as Error).message}`
+        );
+      }
     }
 
     return {
-      outputAssetId: enhanceResult?.outputAssetId ?? hdr.outputAssetId,
-      costCents: (hdr.costCents ?? 0) + (enhanceResult?.costCents ?? 0),
+      outputAssetId: lastOutputAssetId,
+      costCents: totalCost,
       durationMs: Date.now() - started,
-      providerMeta: enhanceResult?.providerMeta,
+      providerMeta: lastProviderMeta,
     };
   }
 

--- a/server/workers/handlers/sky-replace.ts
+++ b/server/workers/handlers/sky-replace.ts
@@ -1,0 +1,65 @@
+/**
+ * sky_replace handler — segment the sky region and composite a cleaner one.
+ *
+ * This is an ML-only operation for MVP. Gray/blown-out skies are the single
+ * most common "fix-this" ask on real-estate shots — a blue or softly clouded
+ * sky lifts a photo from "overcast listing" to "perfect open house."
+ *
+ * Why ML-only
+ *  - Reliable sky segmentation requires a learned model (Replicate sky
+ *    segmentation + SDXL compositing, or a purpose-built real-estate sky
+ *    model). A CPU approximation (HSL threshold on the upper portion of the
+ *    image) would miss tree lines, rooflines, and reflections — the failures
+ *    would look worse than no correction at all. Better to wait on the model
+ *    bakeoff than ship a handler that regresses quality.
+ *
+ * Behaviour
+ *  - Calls the provider with `model: "sky-replace"`.
+ *  - If `MODEL_REGISTRY["sky-replace"]` is still `null`
+ *    (i.e., not yet pinned), the provider throws
+ *    `ProviderUnavailableError`. We re-throw so `pipeline_auto` marks the
+ *    step as best-effort-failed and keeps the previous rendition intact.
+ *
+ * Inputs it accepts (via job.inputParams, all optional)
+ *  - `sky_preset`: 'clear' | 'dramatic' | 'sunset' | 'golden'
+ *    — sent verbatim to the provider; the model maps preset → reference sky.
+ *  - `strength`: float 0..1 — how strongly the new sky is composited.
+ *
+ * When a good model is pinned, ~zero code changes here — we just update
+ * `MODEL_REGISTRY` and the handler starts working.
+ */
+
+import type { EditJob } from "@shared/schema";
+import type { HandlerResult } from "./pipeline-auto";
+import { getPhotoModelProvider } from "../../services/photo-providers";
+import { runSingleAssetCorrection } from "./correction-common";
+
+export async function handleSkyReplace(job: EditJob): Promise<HandlerResult> {
+  return runSingleAssetCorrection(job, {
+    stage: "sky_replace",
+    bracketStatus: "sky_replaced",
+    produce: async ({ inputAsset }) => {
+      const provider = getPhotoModelProvider();
+      // Let ProviderUnavailableError bubble — pipeline_auto catches and
+      // records the step as failed without touching the chain.
+      const result = await provider.run({
+        imageUrls: [inputAsset.sourceUrl],
+        model: "sky-replace",
+        editJobId: job.id,
+        projectId: job.projectId,
+        params: (job.inputParams as Record<string, unknown> | undefined) ?? undefined,
+      });
+      const res = await fetch(result.outputUrl);
+      if (!res.ok) {
+        throw new Error(
+          `Failed to fetch provider output: ${res.status} ${res.statusText}`
+        );
+      }
+      return {
+        outputBuffer: Buffer.from(await res.arrayBuffer()),
+        costCents: result.costCents,
+        providerMeta: { ...(result.providerMeta ?? {}), fallback: false },
+      };
+    },
+  });
+}

--- a/server/workers/handlers/white-balance.ts
+++ b/server/workers/handlers/white-balance.ts
@@ -1,0 +1,131 @@
+/**
+ * white_balance handler — remove colour cast from interior and exterior
+ * real-estate shots.
+ *
+ * Why this matters in real-estate: mixed lighting (tungsten lamps + daylight
+ * through windows + LED downlights) gives photos a yellow-orange cast that
+ * reads as "cheap" to buyers. Listings that look neutral-white feel more
+ * professional. This is often the single biggest perceived-quality lift.
+ *
+ * Strategy
+ *  - Try the provider (`white-balance` logical model) first. When we pin a
+ *    Replicate colour-constancy model this path will win — ML models handle
+ *    mixed-lighting scenes better than global-average methods.
+ *  - Fall back to gray-world on ProviderUnavailableError. Gray-world assumes
+ *    the average colour of a scene is neutral gray; it computes per-channel
+ *    means and scales each channel so they converge. Fast, deterministic,
+ *    works well for single-cast scenes (all tungsten, all daylight) but
+ *    underperforms on mixed lighting — which is why the provider path
+ *    exists.
+ *
+ * Math on the gray-world step
+ *  - Let μR, μG, μB be the mean of each channel across the image.
+ *  - Let μ = (μR + μG + μB) / 3.
+ *  - Scale R by μ/μR, G by μ/μG, B by μ/μB. The three channels then all
+ *    average to μ — the cast is gone.
+ *  - We clamp the scale to [0.5, 2.0] so over-corrected shots don't
+ *    introduce weird magenta/green casts on already-neutral photos.
+ */
+
+import sharp from "sharp";
+import type { EditJob } from "@shared/schema";
+import type { HandlerResult } from "./pipeline-auto";
+import {
+  getPhotoModelProvider,
+  ProviderUnavailableError,
+} from "../../services/photo-providers";
+import {
+  fetchAssetBuffer,
+  runSingleAssetCorrection,
+} from "./correction-common";
+
+/** Bounds on per-channel gain so we can't turn a neutral image magenta. */
+const MIN_GAIN = 0.5;
+const MAX_GAIN = 2.0;
+
+export async function handleWhiteBalance(job: EditJob): Promise<HandlerResult> {
+  return runSingleAssetCorrection(job, {
+    stage: "white_balance",
+    bracketStatus: "balanced",
+    produce: async ({ inputAsset }) => {
+      const provider = getPhotoModelProvider();
+
+      // Try the provider path first. Any ProviderUnavailableError falls
+      // through to CPU gray-world — every other error escalates.
+      try {
+        const result = await provider.run({
+          imageUrls: [inputAsset.sourceUrl],
+          model: "white-balance",
+          editJobId: job.id,
+          projectId: job.projectId,
+        });
+        const res = await fetch(result.outputUrl);
+        if (!res.ok) {
+          throw new Error(
+            `Failed to fetch provider output: ${res.status} ${res.statusText}`
+          );
+        }
+        return {
+          outputBuffer: Buffer.from(await res.arrayBuffer()),
+          costCents: result.costCents,
+          providerMeta: { ...(result.providerMeta ?? {}), fallback: false },
+        };
+      } catch (err) {
+        if (!(err instanceof ProviderUnavailableError)) throw err;
+        console.log(
+          `🎨 WHITE_BALANCE: provider unavailable (${err.message}) — using gray-world fallback`
+        );
+      }
+
+      const outputBuffer = await grayWorldBalance(inputAsset.sourceUrl);
+      return {
+        outputBuffer,
+        costCents: 0,
+        providerMeta: { provider: "local-gray-world" },
+      };
+    },
+  });
+}
+
+/**
+ * Apply gray-world white balance to a JPEG URL. Returns a mozjpeg-encoded
+ * buffer ready to upload. Uses Sharp's channel stats + `.linear()` for the
+ * per-channel scale.
+ */
+async function grayWorldBalance(sourceUrl: string): Promise<Buffer> {
+  const src = await fetchAssetBuffer(sourceUrl);
+
+  // `.stats()` returns per-channel mean, min, max, stdev. We use mean.
+  const stats = await sharp(src, { failOn: "none" }).stats();
+  const channels = stats.channels;
+  if (!channels || channels.length < 3) {
+    // Grayscale or unsupported — return bytes unchanged so downstream
+    // handlers keep working. Still bumps the version (a rotation-honouring
+    // re-encode) so the DB state stays consistent.
+    return sharp(src, { failOn: "none" })
+      .rotate()
+      .jpeg({ quality: 82, mozjpeg: true })
+      .toBuffer();
+  }
+
+  const [rMean, gMean, bMean] = channels.slice(0, 3).map((c) => c.mean);
+  const overall = (rMean + gMean + bMean) / 3;
+
+  const gainR = clamp(overall / rMean, MIN_GAIN, MAX_GAIN);
+  const gainG = clamp(overall / gMean, MIN_GAIN, MAX_GAIN);
+  const gainB = clamp(overall / bMean, MIN_GAIN, MAX_GAIN);
+
+  // `.linear(a, b)` computes `a * pixel + b`. Per-channel arrays apply
+  // the scale to each RGB channel independently, which is exactly the
+  // gray-world transform.
+  return sharp(src, { failOn: "none" })
+    .rotate()
+    .linear([gainR, gainG, gainB], [0, 0, 0])
+    .jpeg({ quality: 82, mozjpeg: true })
+    .toBuffer();
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(hi, Math.max(lo, n));
+}

--- a/server/workers/handlers/window-pull.ts
+++ b/server/workers/handlers/window-pull.ts
@@ -1,0 +1,59 @@
+/**
+ * window_pull handler — recover highlight detail in blown-out windows.
+ *
+ * In interior real-estate shots, the bright exterior visible through
+ * windows is 8–12 stops brighter than the room. Even with HDR bracketing,
+ * windows can end up clipped to pure white — especially on single-frame
+ * shots. "Window pull" is the editorial pass that brings the view back:
+ * segmenting the window region, reducing exposure locally, and restoring
+ * mid-tones and saturation.
+ *
+ * Why ML for this one
+ *  - Pixel-space methods (e.g. "any pixel > 252/255 → darken") collapse
+ *    on reflections, glossy trim, or anything that isn't a window. You
+ *    need a learned mask. Same reasoning as sky-replace: CPU fallback
+ *    would regress quality more often than it helps.
+ *
+ * Hand-off contract with the provider
+ *  - Logical model `"window-pull"`. The provider's MODEL_REGISTRY entry
+ *    stays `null` until per-model bakeoff pins a version. When that
+ *    happens, no code change here.
+ *  - `job.inputParams.target_ev`: optional target EV offset for the
+ *    recovered window region (default -1.5). Sent through verbatim.
+ *  - If the provider is unavailable we re-throw — this is intentionally
+ *    a hard-fail so pipeline_auto can record it and keep the previous
+ *    rendition intact. No silent no-ops.
+ */
+
+import type { EditJob } from "@shared/schema";
+import type { HandlerResult } from "./pipeline-auto";
+import { getPhotoModelProvider } from "../../services/photo-providers";
+import { runSingleAssetCorrection } from "./correction-common";
+
+export async function handleWindowPull(job: EditJob): Promise<HandlerResult> {
+  return runSingleAssetCorrection(job, {
+    stage: "window_pull",
+    bracketStatus: "window_pulled",
+    produce: async ({ inputAsset }) => {
+      const provider = getPhotoModelProvider();
+      const result = await provider.run({
+        imageUrls: [inputAsset.sourceUrl],
+        model: "window-pull",
+        editJobId: job.id,
+        projectId: job.projectId,
+        params: (job.inputParams as Record<string, unknown> | undefined) ?? undefined,
+      });
+      const res = await fetch(result.outputUrl);
+      if (!res.ok) {
+        throw new Error(
+          `Failed to fetch provider output: ${res.status} ${res.statusText}`
+        );
+      }
+      return {
+        outputBuffer: Buffer.from(await res.arrayBuffer()),
+        costCents: result.costCents,
+        providerMeta: { ...(result.providerMeta ?? {}), fallback: false },
+      };
+    },
+  });
+}

--- a/server/workers/photo-worker.ts
+++ b/server/workers/photo-worker.ts
@@ -24,6 +24,10 @@ import { editJobService } from "../services/edit-job-service";
 import { handlePipelineAuto, type HandlerResult } from "./handlers/pipeline-auto";
 import { handleHdrMerge } from "./handlers/hdr-merge";
 import { handleEnhance } from "./handlers/enhance";
+import { handleWhiteBalance } from "./handlers/white-balance";
+import { handlePerspective } from "./handlers/perspective";
+import { handleSkyReplace } from "./handlers/sky-replace";
+import { handleWindowPull } from "./handlers/window-pull";
 
 /**
  * Map from BullMQ job name → handler fn. Add entries as handlers land.
@@ -34,6 +38,10 @@ type JobHandler = (dbJob: EditJob) => Promise<HandlerResult>;
 const handlers: Partial<Record<PhotoJobName, JobHandler>> = {
   pipeline_auto: handlePipelineAuto,
   hdr_merge: handleHdrMerge,
+  white_balance: handleWhiteBalance,
+  perspective: handlePerspective,
+  window_pull: handleWindowPull,
+  sky_replace: handleSkyReplace,
   enhance: handleEnhance,
 };
 


### PR DESCRIPTION
…w-pull

Complete the Week 3 correction handlers and wire them into pipeline_auto:

- white-balance: provider path first, gray-world CPU fallback on ProviderUnavailableError. Per-channel gain clamped to [0.5, 2.0] so a neutral photo can't end up tinted.
- perspective: provider path first, Sharp affine transform fallback (rotation + shear matrix) with params from job.inputParams. Clamped to +/-15 deg rotation, +/-0.3 shear.
- sky-replace: provider-only. Pixel-space sky detection regresses on tree lines, rooflines, reflections - we'd rather wait for the pinned model than ship a fallback that looks worse than no correction.
- window-pull: provider-only for the same reason.
- correction-common: shared runSingleAssetCorrection helper - resolves input asset, produces buffer, uploads to Firebase, inserts version + bracket pointer update in one transaction. Keeps the four handlers single-responsibility (just the produce step).

pipeline_auto now chains hdr_merge -> white_balance -> perspective -> window_pull -> sky_replace -> enhance, each post-HDR step best-effort. ProviderUnavailableError on unpinned models becomes a soft no-op for the whole run - the HDR output is already a deliverable.

When the bakeoff pins Replicate versions, flipping MODEL_REGISTRY entries activates the respective steps with zero handler changes.

Typecheck clean. Week 3 is 100% complete; ready for Week 6 unlock-download endpoint.