### PR TITLE
Fix: Stripe webhook signature verification needs raw body

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,18 @@ import { startPhotoWorker } from "./workers/photo-worker";
 config();
 
 const app = express();
+
+// Stripe webhooks MUST receive the raw body bytes so
+// `stripe.webhooks.constructEvent` can verify the signature. Mount
+// express.raw on this specific path BEFORE express.json() so the JSON
+// parser doesn't consume the body first — otherwise `req.body` becomes a
+// parsed object, signature verification fails, and every webhook returns
+// 400 silently (symptom: Stripe Checkout succeeds but credits never land).
+app.use(
+  '/api/webhooks/stripe',
+  express.raw({ type: 'application/json', limit: '2mb' })
+);
+
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: false, limit: '50mb' }));
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1888,13 +1888,35 @@ ${campaign.brief}`;
   });
 
   app.post('/api/webhooks/stripe', async (req, res) => {
+    // `req.body` is a Buffer here because we mount `express.raw()` on this
+    // path in server/index.ts. Signature verification REQUIRES the raw
+    // bytes — if the body arrived as a parsed object we'd silently reject
+    // every event.
+    const signature = req.headers['stripe-signature'] as string | undefined;
+    if (!signature) {
+      console.error('❌ STRIPE WEBHOOK: missing stripe-signature header');
+      return res.status(400).send('Missing signature');
+    }
+    if (!Buffer.isBuffer(req.body)) {
+      console.error(
+        '❌ STRIPE WEBHOOK: body is not a Buffer — raw body middleware is not wired (did someone move express.json above the webhook mount?)'
+      );
+      return res.status(500).send('Webhook misconfiguration');
+    }
+
     try {
-      const signature = req.headers['stripe-signature'] as string;
-      const { subscriptionService } = await import("./services/subscription-service");
+      const { subscriptionService } = await import('./services/subscription-service');
       await subscriptionService.handleWebhook(signature, req.body);
       res.status(200).send('OK');
-    } catch (error) {
-      console.error('Webhook error:', error);
+    } catch (error: any) {
+      // Log the full error — signature failures, missing env secret, and
+      // handler crashes all land here. Without the detail we can't
+      // distinguish "Stripe is configured wrong" from "our code blew up."
+      console.error(
+        '❌ STRIPE WEBHOOK: handler failed:',
+        error?.message ?? error,
+        error?.stack ?? ''
+      );
       res.status(400).send('Webhook Error');
     }
   });

--- a/server/scripts/backfill-photo-credits.ts
+++ b/server/scripts/backfill-photo-credits.ts
@@ -1,0 +1,127 @@
+/**
+ * One-off backfill for photo credit pack purchases whose webhooks never
+ * landed successfully. Root cause: until the raw-body middleware was
+ * added (see `server/index.ts`), every Stripe webhook failed signature
+ * verification and the purchase was never credited to the org ledger.
+ *
+ * Usage
+ * -----
+ * From the project root:
+ *
+ *   npx tsx server/scripts/backfill-photo-credits.ts
+ *
+ * What it does
+ *  - Lists recent completed Stripe Checkout sessions (default: last 100).
+ *  - Filters to those flagged `metadata.source=photo_credit_pack` and
+ *    `payment_status=paid`.
+ *  - For each, synthesises a `checkout.session.completed` event and passes
+ *    it through `photoCreditService.handleWebhookEvent`. The service is
+ *    idempotent on `stripeChargeId` so re-running is a no-op for rows
+ *    already credited.
+ *
+ * Why this is safe to re-run
+ *  - Idempotency guard in `recordPurchase` short-circuits if the
+ *    stripe_charge_id is already in the ledger.
+ *  - No writes happen for sessions that don't match the photo-credit-pack
+ *    metadata tag, so subscription purchases are untouched.
+ *
+ * Why it's a script, not a route
+ *  - This is a one-off recovery. Exposing an admin endpoint would require
+ *    auth plumbing we don't need permanently.
+ */
+
+import { config } from "dotenv";
+config();
+
+import Stripe from "stripe";
+import { ENV } from "../config/environment";
+import { photoCreditService } from "../services/photo-credit-service";
+
+async function main() {
+  const stripe = new Stripe(ENV.stripe.secretKey, {
+    apiVersion: "2025-08-27.basil",
+  });
+
+  console.log("🔎 Fetching recent Checkout sessions from Stripe…");
+  const sessions = await stripe.checkout.sessions.list({
+    limit: 100,
+    expand: ["data.payment_intent"],
+  });
+
+  const photoSessions = sessions.data.filter(
+    (s) =>
+      s.mode === "payment" &&
+      s.metadata?.source === "photo_credit_pack" &&
+      s.payment_status === "paid"
+  );
+
+  console.log(
+    `📋 Found ${sessions.data.length} total recent sessions, ${photoSessions.length} are paid photo-credit-pack sessions`
+  );
+
+  if (photoSessions.length === 0) {
+    console.log("✅ Nothing to backfill.");
+    return;
+  }
+
+  let granted = 0;
+  let skipped = 0;
+  let errored = 0;
+
+  for (const session of photoSessions) {
+    try {
+      // Synthesise the exact event shape our handler expects. We pass it
+      // straight into the same webhook handler so there's no divergent
+      // code path — the ledger insert goes through the same idempotency
+      // guards as a real webhook.
+      const event = {
+        id: `evt_backfill_${session.id}`,
+        object: "event",
+        type: "checkout.session.completed",
+        data: { object: session },
+      } as unknown as Stripe.Event;
+
+      const before = await photoCreditService.getBalance(
+        session.metadata?.orgId ?? ""
+      );
+      const handled = await photoCreditService.handleWebhookEvent(event);
+      const after = await photoCreditService.getBalance(
+        session.metadata?.orgId ?? ""
+      );
+
+      if (!handled) {
+        console.log(`⏭️  ${session.id} — not recognised as photo pack`);
+        skipped++;
+        continue;
+      }
+
+      if (before === after) {
+        console.log(
+          `↩️  ${session.id} — already credited (balance unchanged: ${after})`
+        );
+        skipped++;
+      } else {
+        console.log(
+          `💳 ${session.id} — org=${session.metadata?.orgId} granted ${after - before} (balance ${before} → ${after})`
+        );
+        granted++;
+      }
+    } catch (err: any) {
+      console.error(
+        `❌ ${session.id} — error: ${err?.message ?? err}`
+      );
+      errored++;
+    }
+  }
+
+  console.log(
+    `\n✅ Done. granted=${granted}, skipped=${skipped}, errored=${errored}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Symptom: Stripe Checkout payments completed successfully but no credits landed in the ledger. Webhook requests returned 400 silently, Stripe retried, all subsequent retries also failed, no credit was ever recorded.

Root cause: express.json() was applied globally before routes, so the /api/webhooks/stripe handler received req.body as a parsed object. stripe.webhooks.constructEvent() requires the raw bytes of the body for HMAC signature verification - a parsed object can't be verified, so every webhook threw, the outer try/catch returned 400, and no credit was ever applied.

Fix:
- Mount express.raw({ type: 'application/json' }) on /api/webhooks/stripe BEFORE express.json() in server/index.ts. Path-specific middleware wins for that path; the rest of the app still gets JSON parsing.
- Harden the webhook route handler: explicitly verify the body arrived as a Buffer, require the stripe-signature header, log errors with stack so future failures are diagnosable from the console.
- Add backfill-photo-credits.ts - one-off script that replays recent paid Checkout sessions through photoCreditService.handleWebhookEvent. Idempotency on stripe_charge_id makes it safe to re-run. Recovers credits for payments that landed before the webhook fix.

This affected both the photo credit purchase flow and (likely) the existing subscription webhook, though subscription flows may have been partially covered by other code paths.