### PR TITLE
Photo MVP Week 6: pay-on-download + delivery

### DIFF
--- a/MVP_PHOTO_PLAN.md
+++ b/MVP_PHOTO_PLAN.md
@@ -4,30 +4,36 @@
 **Product owner:** Rey (CEO) — see `PRD.md` for full Founder-Grade PRD
 **Engineering owner:** Claude
 **Target:** Paying-customer MVP launch — end of Month 2 (~8 weeks)
-**Last session:** 2026-04-19 — Weeks 1 → 5 code-complete (Week 3 tail landed: white-balance, perspective, sky-replace + window-pull handlers; `pipeline_auto` chains them best-effort). Week 5 blocked only on Rey creating Stripe credit-pack SKUs (envs set). See [§8 Updates log](#8-updates-log).
+**Last session:** 2026-04-19 — Weeks 1 → 6 core code-complete. Week 6 landed pay-on-download (unlock endpoint + per-version + batch ZIP UI, dual-output pipeline). Deferred to Week 7: "mark delivered" flag + archive filters. See [§8 Updates log](#8-updates-log).
 
 > ## 🎯 Where we left off (2026-04-19)
 >
-> Weeks 1 → 5 are code-complete. Week 3 tail landed this session:
-> `white-balance` (provider → gray-world CPU fallback), `perspective`
-> (provider → Sharp affine fallback), `sky-replace` + `window-pull`
-> (provider-only — no CPU approximation on purpose). `pipeline_auto` now
-> chains `hdr_merge → white_balance → perspective → window_pull →
-> sky_replace → enhance` with each post-HDR step best-effort.
+> Weeks 1 → 6 core shipped. Pay-on-download is fully wired:
+> `photoDownloadService` (unlock / planBatch / unlockBatch) with
+> idempotent per-org-per-version receipts in `photo_downloads`; dual-
+> output pipeline so every handler emits clean + watermarked JPEGs in
+> parallel; endpoints for per-version unlock, batch planning/debit, and
+> streamed ZIP via `archiver`; UI for per-version unlock+download, free
+> watermarked preview download, and project-wide "Download all clean"
+> with a plan/confirm dialog. Partial fulfilment on insufficient credits
+> (unlock what you can afford, prompt to top up for the rest).
 >
 > **Next open tasks on the critical path:**
-> 1. **Claude — Week 6:** unlock-download endpoint that debits credits via
->    `photoCreditService.chargeForDownload`, serves the non-watermarked URL,
->    then batch ZIP export.
+> 1. **Claude — Week 7 polish:** Sentry on worker paths, PostHog events
+>    (upload_started, job_succeeded/failed, preview_viewed,
+>    download_unlocked), admin cost-per-job dashboard, failure-recovery
+>    UX, "mark project delivered" flag + archive filters (deferred
+>    from Week 6).
 > 2. **Bakeoff (background) — pin Replicate models** for `sky-replace`,
->    `window-pull`, `perspective`, `white-balance`. Handlers are wired; the
->    `MODEL_REGISTRY` entries just need version ids. No handler changes needed.
+>    `window-pull`, `perspective`, `white-balance`. Handlers are wired;
+>    `MODEL_REGISTRY` entries just need version ids. No handler changes.
 > 3. **Rey — Stripe dashboard (done):** the 3 one-time products are created
 >    and `VITE_STRIPE_PHOTO_{STARTER,GROWTH,AGENCY}_PACK_PRICE_ID` are set.
 >
-> **Quality gates green:** `npm run check` clean. Full chain typechecks.
-> Credit ledger debit is transactional (SELECT FOR UPDATE). Webhook
-> idempotency keyed on stripe_charge_id.
+> **Quality gates green:** `npx tsc --noEmit` clean. Client build clean.
+> Credit ledger debit is transactional (SELECT FOR UPDATE). Unlock +
+> `photo_downloads` insert is transactional. Webhook idempotency keyed
+> on stripe_charge_id; unlock idempotency keyed on (project_id, version_id).
 >
 > **Dev ops reminder:** Cloud Run staging service is provisioned but **off**;
 > Cloud SQL stays off between sessions; local Docker Postgres is the dev DB.
@@ -144,12 +150,13 @@ reuses what works.
 - [x] Org-level balance display _(`GET /api/photo/credits/balance` + `CreditsChip` in both `/photos` and `/photos/:id` headers; low/zero balance tinted amber/red as a top-up nudge)_
 - [x] Checkout flow: Stripe Checkout → webhook → ledger credit _(one-time `mode:payment` Checkout session with orgId/userId/packId metadata; webhook delegates via `subscription-service.handleWebhook` → `photoCreditService.handleWebhookEvent`; idempotent on `stripe_charge_id` so Stripe retries don't double-grant; priceId verified against catalog before grant so tampered metadata can't inflate credits)_
 
-**Week 6 — Pay-on-download + delivery**
-- [ ] Unlock-download endpoint (debits credits, returns non-watermarked URL)
-- [ ] Individual image download
-- [ ] Batch download (ZIP)
-- [ ] "Mark project delivered" flag
-- [ ] Project history/archive filters
+**Week 6 — Pay-on-download + delivery** 🟢 _core code-complete 2026-04-19 (unlock + per-version + batch ZIP + UI). "Mark delivered" flag + archive filters deferred to Week 7 polish._
+- [x] Unlock-download endpoint (debits credits, returns non-watermarked URL) _(`POST /api/photo/projects/:id/versions/:versionId/unlock` — idempotent per org+version, `InsufficientCreditsError` → 402, `VersionNotFoundError` → 404, `NoCleanRenditionError` → 409; `photoDownloadService` owns ledger debit + `photo_downloads` receipt inside one DB transaction)_
+- [x] Individual image download _(`UnlockAndDownloadButton` in `MergedPreview` — fetches clean URL after unlock, blob-downloads with `{filename}-clean.jpg`; `PreviewDownloadButton` keeps the free watermarked path alive)_
+- [x] Batch download (ZIP) _(`POST /versions/batch-unlock` with `planOnly` for the confirm dialog + `GET /versions/download.zip?versionIds=…` streaming via `archiver`; UI: `BatchUnlockButton` in project header pulls currents from cached per-asset version queries, shows `{chargeable, alreadyUnlocked, missingClean}` + balance, partial-fulfilment on 402)_
+- [x] Dual-output pipeline _(every handler now emits `clean` + `watermarked` JPEGs in parallel from the same source buffer — `renderDualOutput` / `cleanFromRaw` + `watermarkFromRaw` — and stores both URLs on `editVersions.{outputUrl,cleanOutputUrl}`; zero AI re-run at unlock time)_
+- [ ] "Mark project delivered" flag _(deferred to Week 7 — needs retention/archive UI)_
+- [ ] Project history/archive filters _(deferred to Week 7)_
 
 **Week 7 — Polish + telemetry**
 - [ ] Sentry wiring on all worker paths
@@ -283,6 +290,36 @@ processing success rate
   version chip strip, download-with-filename button. **Open on critical path:**
   white balance, perspective, sky replace, window pull (each a new handler on
   the provider interface), then Week 5–6 Stripe SKUs.
+- **2026-04-19 — Week 6 core shipped (pay-on-download + delivery).** New
+  `photoDownloadService` (`unlock` / `planBatch` / `unlockBatch`) enforces
+  the two invariants: pay-once-per-version-per-org (idempotency receipt in
+  `photo_downloads` — lost-tab re-downloads are free) and atomic
+  debit+receipt (single `db.transaction`). Partial-fulfilment on overdraft
+  is deliberate: versions charged before an `InsufficientCreditsError`
+  stay unlocked, rest aren't — UI renders "unlocked N of M, top up for
+  the rest" cleaner than an all-or-nothing rollback. **Dual-output
+  pipeline:** every handler (`hdr-merge`, `correction-common`, `enhance`)
+  now emits `clean` + `watermarked` JPEGs in parallel from the same
+  source/raw buffer (`renderDualOutput`, `cleanFromRaw` +
+  `watermarkFromRaw`) and stores both URLs on `editVersions`. Zero AI
+  re-run at unlock — the paid path is a DB flip + credit debit + signed
+  URL. **Endpoints:** `POST /projects/:id/versions/:versionId/unlock`,
+  `POST /projects/:id/versions/batch-unlock` (with `planOnly` for the
+  confirm UI), `GET /projects/:id/versions/download.zip?versionIds=…`
+  streaming via `archiver`. **UI:** `UnlockAndDownloadButton` in the
+  merged-preview block (per-version; 1-credit confirm + blob download +
+  balance invalidation; 402 → shared `InsufficientCreditsDialog`;
+  disabled with "No clean rendition" when `cleanOutputUrl` is null for
+  pre-Week-6 rows). `PreviewDownloadButton` keeps the free watermarked
+  path alive. `BatchUnlockButton` in the project header: plans across
+  all bracket mergeds using cached versions queries, shows a
+  `{chargeable, alreadyUnlocked, missingClean}` breakdown + balance,
+  unlocks chargeable set, re-plans post-debit to filter out anything
+  partial-fulfilment couldn't cover, then fetches the ZIP via authed
+  `fetch` + blob download (plain `window.location` won't send the
+  Authorization header). Typecheck + client build clean. Deferred:
+  "Mark project delivered" flag + archive filters — retention surface
+  rolls up into Week 7 polish.
 - **2026-04-19 — Week 3 tail shipped.** All four remaining correction
   handlers landed: `white-balance` (gray-world CPU fallback with per-channel
   gain clamped to `[0.5, 2.0]`), `perspective` (Sharp affine transform

--- a/client/src/pages/photos/detail.tsx
+++ b/client/src/pages/photos/detail.tsx
@@ -3,21 +3,33 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRoute } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
-import { getAuthHeaders } from "@/lib/queryClient";
+import { apiRequest, getAuthHeaders } from "@/lib/queryClient";
 import {
   ArrowLeft,
   Camera,
+  Coins,
   Download,
   History,
   Layers,
   Loader2,
+  Lock,
   MapPin,
+  Package,
   UploadCloud,
   ImageOff,
   AlertTriangle,
   RefreshCw,
   Sparkles,
+  Unlock,
 } from "lucide-react";
 import type { PhotoAsset, PhotoProject } from "@shared/schema";
 import { CreditsChip } from "@/components/photos/credits-chip";
@@ -65,6 +77,12 @@ type EditVersion = {
   jobId: number | null;
   versionNumber: number;
   outputUrl: string;
+  /**
+   * URL to the clean (unwatermarked) rendition. Populated from Week 6
+   * onwards — older rows may be null, in which case the unlock endpoint
+   * responds 409 and the UI shows "re-run pipeline to unlock".
+   */
+  cleanOutputUrl: string | null;
   watermarked: boolean | null;
   isCurrent: boolean | null;
   createdAt: string | null;
@@ -78,6 +96,40 @@ type EditVersion = {
   } | null;
 };
 type VersionsResponse = { versions: EditVersion[] };
+
+type UnlockResponse = {
+  url: string;
+  charged: boolean;
+  downloadId: number;
+  versionId: number;
+  balanceAfter: number;
+};
+
+type BatchUnlockResponse = {
+  unlocked: Array<{
+    versionId: number;
+    url: string;
+    charged: boolean;
+    downloadId: number;
+  }>;
+  failed?: {
+    reason: "insufficient_credits";
+    required: number;
+    available: number;
+  };
+  balance: number;
+};
+
+type BatchPlanResponse = {
+  plan: {
+    chargeable: number[];
+    alreadyUnlocked: number[];
+    missingClean: number[];
+    invalid: number[];
+    creditsNeeded: number;
+  };
+  balance: number;
+};
 
 export default function PhotosDetail() {
   const [, params] = useRoute<{ id: string }>("/photos/:id");
@@ -126,7 +178,12 @@ export default function PhotosDetail() {
           </div>
           <div className="flex items-center gap-3">
             <CreditsChip />
-            {id && project ? <TestQueueButton projectId={id} /> : null}
+            {id && project ? (
+              <>
+                <BatchUnlockButton projectId={id} groups={groups} />
+                <TestQueueButton projectId={id} />
+              </>
+            ) : null}
           </div>
         </div>
       </header>
@@ -870,7 +927,14 @@ function MergedPreview({
               {mergedAsset.widthPx}×{mergedAsset.heightPx}
             </span>
           ) : null}
-          <DownloadButton url={afterUrl} fileName={mergedAsset.fileName} />
+          <PreviewDownloadButton url={afterUrl} fileName={mergedAsset.fileName} />
+          {activeVersion ? (
+            <UnlockAndDownloadButton
+              projectId={mergedAsset.projectId}
+              version={activeVersion}
+              fileName={mergedAsset.fileName}
+            />
+          ) : null}
         </div>
       </div>
       {versions.length > 1 ? (
@@ -1059,11 +1123,11 @@ function humaniseJobType(jobType: string): string {
 }
 
 /**
- * Downloads a remote file via fetch → object URL so we can set a nice
- * filename. Hitting the Firebase signed URL with `download` attribute
- * alone leaves the Firebase-generated filename, which users hate.
+ * Free-tier preview download — watermarked rendition. No credits charged.
+ * Pulled via fetch → object URL so we can set a nice filename (hitting the
+ * Firebase signed URL with a download attribute leaves the storage key).
  */
-function DownloadButton({ url, fileName }: { url: string; fileName: string }) {
+function PreviewDownloadButton({ url, fileName }: { url: string; fileName: string }) {
   const [pending, setPending] = useState(false);
   const { toast } = useToast();
 
@@ -1073,14 +1137,7 @@ function DownloadButton({ url, fileName }: { url: string; fileName: string }) {
       const res = await fetch(url);
       if (!res.ok) throw new Error(`Download failed: ${res.status}`);
       const blob = await res.blob();
-      const objectUrl = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = objectUrl;
-      a.download = fileName;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(objectUrl);
+      await triggerBlobDownload(blob, prefixFileName(fileName, "preview"));
     } catch (err) {
       toast({
         title: "Download failed",
@@ -1099,13 +1156,511 @@ function DownloadButton({ url, fileName }: { url: string; fileName: string }) {
       className="h-6 px-2 text-[11px]"
       onClick={handleClick}
       disabled={pending}
+      title="Download the watermarked preview (free)"
     >
       {pending ? (
         <Loader2 className="w-3 h-3 mr-1 animate-spin" />
       ) : (
         <Download className="w-3 h-3 mr-1" />
       )}
-      Download
+      Preview
     </Button>
   );
+}
+
+/**
+ * Paid unlock + download (1 credit). Calls the unlock endpoint, which is
+ * idempotent per-org-per-version — repeat clicks after the first don't
+ * re-bill. On 402 we pop the top-up modal seeded with the shortfall so the
+ * user can buy credits in one click.
+ */
+function UnlockAndDownloadButton({
+  projectId,
+  version,
+  fileName,
+}: {
+  projectId: number;
+  version: EditVersion;
+  fileName: string;
+}) {
+  const [pending, setPending] = useState(false);
+  const [insufficient, setInsufficient] = useState<{
+    required: number;
+    available: number;
+  } | null>(null);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  // Pre-Week-6 renditions have no clean URL — disable the button and
+  // surface the "re-run pipeline" guidance so users don't keep clicking.
+  const noClean = !version.cleanOutputUrl;
+
+  const handleClick = async () => {
+    if (noClean) return;
+    try {
+      setPending(true);
+      const res = await fetch(
+        `/api/photo/projects/${projectId}/versions/${version.id}/unlock`,
+        {
+          method: "POST",
+          headers: await getAuthHeaders(),
+          credentials: "include",
+        }
+      );
+
+      if (res.status === 402) {
+        const body = (await res.json()) as {
+          required: number;
+          available: number;
+        };
+        setInsufficient({ required: body.required, available: body.available });
+        return;
+      }
+      if (!res.ok) {
+        const text = (await res.text()) || res.statusText;
+        throw new Error(`${res.status}: ${text}`);
+      }
+
+      const data = (await res.json()) as UnlockResponse;
+      // Fetch clean bytes and trigger download. We could `<a href>` the
+      // signed URL directly, but fetch-and-blob lets us set a nice filename.
+      const cleanRes = await fetch(data.url);
+      if (!cleanRes.ok) {
+        throw new Error(`Clean download failed: ${cleanRes.status}`);
+      }
+      const blob = await cleanRes.blob();
+      await triggerBlobDownload(blob, prefixFileName(fileName, "clean"));
+
+      // Refresh the balance chip. If we didn't actually charge (already
+      // unlocked), the invalidation is still cheap and keeps the UI honest.
+      queryClient.invalidateQueries({
+        queryKey: ["/api/photo/credits/balance"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["/api/photo/credits/ledger"],
+      });
+
+      toast({
+        title: data.charged ? "1 credit spent" : "Already unlocked",
+        description: data.charged
+          ? `Clean rendition downloaded · ${data.balanceAfter} credits remaining`
+          : `You've already paid for this version. Free re-download.`,
+      });
+    } catch (err) {
+      toast({
+        title: "Unlock failed",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        size="sm"
+        className={`h-6 px-2 text-[11px] ${
+          noClean
+            ? "bg-gray-100 text-gray-400"
+            : "bg-ailldoit-accent hover:bg-ailldoit-accent/90 text-white"
+        }`}
+        onClick={handleClick}
+        disabled={pending || noClean}
+        title={
+          noClean
+            ? "Pre-Week-6 version — re-run the pipeline to generate a clean rendition"
+            : "Spend 1 credit to download the full-res, unwatermarked image"
+        }
+        data-testid={`unlock-version-${version.id}`}
+      >
+        {pending ? (
+          <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+        ) : noClean ? (
+          <Lock className="w-3 h-3 mr-1" />
+        ) : (
+          <Unlock className="w-3 h-3 mr-1" />
+        )}
+        {noClean ? "No clean rendition" : "Unlock (1 credit)"}
+      </Button>
+      <InsufficientCreditsDialog
+        open={!!insufficient}
+        onOpenChange={(v) => !v && setInsufficient(null)}
+        required={insufficient?.required ?? 0}
+        available={insufficient?.available ?? 0}
+      />
+    </>
+  );
+}
+
+/**
+ * Project-level batch unlock: collects the current rendition for every
+ * bracket group that has one, plans the debit, confirms with the user, then
+ * unlocks and streams the resulting ZIP. Splits payment (unlock) from
+ * delivery (zip) so a flaky browser retry doesn't re-bill.
+ */
+function BatchUnlockButton({
+  projectId,
+  groups,
+}: {
+  projectId: string;
+  groups: BracketGroup[];
+}) {
+  const [planOpen, setPlanOpen] = useState(false);
+  const [plan, setPlan] = useState<BatchPlanResponse | null>(null);
+  const [pending, setPending] = useState(false);
+  const [insufficient, setInsufficient] = useState<{
+    required: number;
+    available: number;
+  } | null>(null);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  // Candidate version ids: one per bracket group's current merged asset's
+  // current version. We hit the versions endpoint per asset to know the
+  // current version id — but since we already render those ids on the page
+  // we can collect them from the cached queries.
+  const candidateAssetIds = groups
+    .map((g) => g.mergedAsset?.id)
+    .filter((id): id is number => typeof id === "number");
+
+  const openPlan = async () => {
+    if (candidateAssetIds.length === 0) {
+      toast({
+        title: "Nothing to unlock yet",
+        description:
+          "Run the pipeline on at least one bracket first — then come back to download the clean batch.",
+      });
+      return;
+    }
+    try {
+      setPending(true);
+      // Collect current version ids for each merged asset. We fetch the
+      // versions endpoint per asset — cheap, no pagination, and the results
+      // are already cached for most of the page.
+      const versionIds: number[] = [];
+      for (const assetId of candidateAssetIds) {
+        const cached = queryClient.getQueryData<VersionsResponse>([
+          `/api/photo/projects/${projectId}/assets/${assetId}/versions`,
+        ]);
+        const versions =
+          cached?.versions ??
+          (await (async () => {
+            const r = await fetch(
+              `/api/photo/projects/${projectId}/assets/${assetId}/versions`,
+              { headers: await getAuthHeaders(), credentials: "include" }
+            );
+            if (!r.ok) return [] as EditVersion[];
+            return (((await r.json()) as VersionsResponse).versions ?? []);
+          })());
+        const current =
+          versions.find((v) => v.isCurrent) ??
+          versions
+            .slice()
+            .sort((a, b) => b.versionNumber - a.versionNumber)[0];
+        if (current?.cleanOutputUrl) versionIds.push(current.id);
+      }
+
+      if (versionIds.length === 0) {
+        toast({
+          title: "No clean renditions available",
+          description:
+            "Re-run the pipeline on your brackets — older versions don't have clean renditions yet.",
+        });
+        return;
+      }
+
+      // Plan — no debit, just "how many credits will this cost".
+      const res = await apiRequest(
+        "POST",
+        `/api/photo/projects/${projectId}/versions/batch-unlock`,
+        { versionIds, planOnly: true }
+      );
+      const data = (await res.json()) as BatchPlanResponse;
+      setPlan(data);
+      setPlanOpen(true);
+    } catch (err) {
+      toast({
+        title: "Couldn't plan batch",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const confirmDownload = async () => {
+    if (!plan) return;
+    try {
+      setPending(true);
+
+      const allIds = [...plan.plan.chargeable, ...plan.plan.alreadyUnlocked];
+      if (allIds.length === 0) {
+        toast({
+          title: "Nothing to download",
+          description: "None of the requested versions have a clean rendition.",
+        });
+        setPlanOpen(false);
+        return;
+      }
+
+      // Debit credits for the chargeable set. Already-unlocked ids are
+      // tolerated by the unlock endpoint (idempotent) so we can pass the
+      // union and not worry about reconciliation here.
+      if (plan.plan.chargeable.length > 0) {
+        const unlockRes = await apiRequest(
+          "POST",
+          `/api/photo/projects/${projectId}/versions/batch-unlock`,
+          { versionIds: plan.plan.chargeable }
+        );
+        const unlockData = (await unlockRes.json()) as BatchUnlockResponse;
+        if (unlockData.failed?.reason === "insufficient_credits") {
+          setInsufficient({
+            required: unlockData.failed.required,
+            available: unlockData.failed.available,
+          });
+          // Partial-fulfilment handling: keep the already-charged subset —
+          // those ids will still download correctly in the ZIP.
+          // We refresh balance and fall through so the user at least gets
+          // the photos they paid for.
+        }
+        queryClient.invalidateQueries({
+          queryKey: ["/api/photo/credits/balance"],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["/api/photo/credits/ledger"],
+        });
+      }
+
+      // Now stream the zip. Re-query the plan so we don't ask for versions
+      // the user couldn't afford (partial fulfilment).
+      const replanRes = await apiRequest(
+        "POST",
+        `/api/photo/projects/${projectId}/versions/batch-unlock`,
+        { versionIds: allIds, planOnly: true }
+      );
+      const replan = (await replanRes.json()) as BatchPlanResponse;
+      const downloadableIds = replan.plan.alreadyUnlocked;
+      if (downloadableIds.length === 0) {
+        setPlanOpen(false);
+        return;
+      }
+
+      const zipUrl =
+        `/api/photo/projects/${projectId}/versions/download.zip` +
+        `?versionIds=${downloadableIds.join(",")}`;
+      const zipRes = await fetch(zipUrl, {
+        headers: await getAuthHeaders(),
+        credentials: "include",
+      });
+      if (!zipRes.ok) {
+        const text = (await zipRes.text()) || zipRes.statusText;
+        throw new Error(`${zipRes.status}: ${text}`);
+      }
+      const blob = await zipRes.blob();
+      await triggerBlobDownload(
+        blob,
+        `ailldoit-project-${projectId}-${Date.now()}.zip`
+      );
+
+      toast({
+        title: `Downloaded ${downloadableIds.length} clean rendition${downloadableIds.length === 1 ? "" : "s"}`,
+        description:
+          plan.plan.chargeable.length > 0
+            ? `${plan.plan.chargeable.length} newly unlocked · ${plan.plan.alreadyUnlocked.length} previously paid`
+            : "All were previously unlocked — no credits spent.",
+      });
+
+      setPlanOpen(false);
+      setPlan(null);
+    } catch (err) {
+      toast({
+        title: "Batch download failed",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const creditsNeeded = plan?.plan.creditsNeeded ?? 0;
+  const balance = plan?.balance ?? 0;
+  const canAfford = balance >= creditsNeeded;
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={openPlan}
+        disabled={pending || candidateAssetIds.length === 0}
+        data-testid="batch-unlock-button"
+      >
+        {pending ? (
+          <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+        ) : (
+          <Package className="w-3 h-3 mr-1" />
+        )}
+        Download all clean
+      </Button>
+      <Dialog open={planOpen} onOpenChange={setPlanOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Download all clean renditions</DialogTitle>
+            <DialogDescription>
+              One credit per version. Already-unlocked versions are free.
+            </DialogDescription>
+          </DialogHeader>
+          {plan ? (
+            <div className="text-sm space-y-2">
+              <div className="flex justify-between">
+                <span className="text-ailldoit-muted">New unlocks</span>
+                <span className="font-medium">
+                  {plan.plan.chargeable.length} ×{" "}
+                  <Coins className="w-3 h-3 inline" /> {creditsNeeded} credit
+                  {creditsNeeded === 1 ? "" : "s"}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-ailldoit-muted">Already unlocked</span>
+                <span className="font-medium">
+                  {plan.plan.alreadyUnlocked.length} · free
+                </span>
+              </div>
+              {plan.plan.missingClean.length > 0 ? (
+                <div className="flex justify-between text-amber-700">
+                  <span>Missing clean rendition</span>
+                  <span className="font-medium">
+                    {plan.plan.missingClean.length} skipped
+                  </span>
+                </div>
+              ) : null}
+              <div className="h-px bg-gray-200 my-2" />
+              <div className="flex justify-between">
+                <span className="text-ailldoit-muted">Your balance</span>
+                <span
+                  className={`font-medium ${canAfford ? "text-emerald-700" : "text-red-700"}`}
+                >
+                  {balance} credit{balance === 1 ? "" : "s"}
+                </span>
+              </div>
+              {!canAfford ? (
+                <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
+                  You'll unlock the first {balance} versions; the remaining{" "}
+                  {creditsNeeded - balance} need a top-up.
+                </p>
+              ) : null}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center py-8 text-ailldoit-muted">
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Planning…
+            </div>
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setPlanOpen(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={confirmDownload}
+              disabled={pending || !plan}
+              className="bg-ailldoit-accent hover:bg-ailldoit-accent/90 text-white"
+            >
+              {pending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Downloading…
+                </>
+              ) : creditsNeeded > 0 ? (
+                `Spend ${Math.min(creditsNeeded, balance)} & download`
+              ) : (
+                "Download ZIP"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <InsufficientCreditsDialog
+        open={!!insufficient}
+        onOpenChange={(v) => !v && setInsufficient(null)}
+        required={insufficient?.required ?? 0}
+        available={insufficient?.available ?? 0}
+      />
+    </>
+  );
+}
+
+/**
+ * Shared 402 prompt. Keeps the copy + CTA consistent between the per-version
+ * unlock and the batch path. Dispatches a window event the CreditsChip
+ * can listen to — or simply tells the user to click the chip — we go with
+ * the latter for MVP since a cross-component bus is overkill.
+ */
+function InsufficientCreditsDialog({
+  open,
+  onOpenChange,
+  required,
+  available,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  required: number;
+  available: number;
+}) {
+  const shortfall = Math.max(0, required - available);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Coins className="w-5 h-5 text-amber-600" />
+            Top up to finish unlocking
+          </DialogTitle>
+          <DialogDescription>
+            You need {shortfall} more credit{shortfall === 1 ? "" : "s"} to
+            unlock this. Your balance is {available}
+            {required > 1 ? ` · ${required} required` : ""}.
+          </DialogDescription>
+        </DialogHeader>
+        <p className="text-sm text-ailldoit-muted">
+          Click <span className="font-medium">Buy</span> on the credits chip in
+          the header to purchase a top-up pack. You'll come back here
+          automatically after checkout.
+        </p>
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>Got it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Download helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function triggerBlobDownload(blob: Blob, fileName: string): Promise<void> {
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement("a");
+    a.href = objectUrl;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+/** Inserts a suffix before the file extension, e.g. "shot.jpg" + "clean" → "shot-clean.jpg" */
+function prefixFileName(fileName: string, suffix: string): string {
+  const dot = fileName.lastIndexOf(".");
+  if (dot <= 0) return `${fileName}-${suffix}`;
+  return `${fileName.slice(0, dot)}-${suffix}${fileName.slice(dot)}`;
 }

--- a/client/src/pages/photos/detail.tsx
+++ b/client/src/pages/photos/detail.tsx
@@ -1336,31 +1336,35 @@ function BatchUnlockButton({
     }
     try {
       setPending(true);
-      // Collect current version ids for each merged asset. We fetch the
-      // versions endpoint per asset — cheap, no pagination, and the results
-      // are already cached for most of the page.
-      const versionIds: number[] = [];
-      for (const assetId of candidateAssetIds) {
-        const cached = queryClient.getQueryData<VersionsResponse>([
-          `/api/photo/projects/${projectId}/assets/${assetId}/versions`,
-        ]);
-        const versions =
-          cached?.versions ??
-          (await (async () => {
-            const r = await fetch(
-              `/api/photo/projects/${projectId}/assets/${assetId}/versions`,
-              { headers: await getAuthHeaders(), credentials: "include" }
-            );
-            if (!r.ok) return [] as EditVersion[];
-            return (((await r.json()) as VersionsResponse).versions ?? []);
-          })());
-        const current =
-          versions.find((v) => v.isCurrent) ??
-          versions
-            .slice()
-            .sort((a, b) => b.versionNumber - a.versionNumber)[0];
-        if (current?.cleanOutputUrl) versionIds.push(current.id);
-      }
+      // Collect current version ids for each merged asset. Fetches run in
+      // parallel (Promise.all) — each call is independent and the results
+      // are mostly cache hits on the React Query store anyway.
+      const perAsset = await Promise.all(
+        candidateAssetIds.map(async (assetId) => {
+          const cached = queryClient.getQueryData<VersionsResponse>([
+            `/api/photo/projects/${projectId}/assets/${assetId}/versions`,
+          ]);
+          const versions =
+            cached?.versions ??
+            (await (async () => {
+              const r = await fetch(
+                `/api/photo/projects/${projectId}/assets/${assetId}/versions`,
+                { headers: await getAuthHeaders(), credentials: "include" }
+              );
+              if (!r.ok) return [] as EditVersion[];
+              return (((await r.json()) as VersionsResponse).versions ?? []);
+            })());
+          const current =
+            versions.find((v) => v.isCurrent) ??
+            versions
+              .slice()
+              .sort((a, b) => b.versionNumber - a.versionNumber)[0];
+          return current?.cleanOutputUrl ? current.id : null;
+        })
+      );
+      const versionIds = perAsset.filter(
+        (id): id is number => typeof id === "number"
+      );
 
       if (versionIds.length === 0) {
         toast({

--- a/server/routes/photo-routes.ts
+++ b/server/routes/photo-routes.ts
@@ -14,6 +14,7 @@
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
 import archiver from "archiver";
+import { Readable } from "node:stream";
 import { z } from "zod";
 import { authenticateToken } from "../middleware/auth";
 import { organizationService } from "../services/organization-service";
@@ -840,25 +841,51 @@ router.get(
       });
       archive.pipe(res);
 
-      for (const version of plan.alreadyUnlocked) {
-        if (!version.cleanOutputUrl) continue; // belt-and-braces
-        try {
-          const r = await fetch(version.cleanOutputUrl);
-          if (!r.ok || !r.body) {
-            console.warn(
-              `⚠️ PHOTO: Skipping version ${version.id} in zip — fetch ${r.status}`
-            );
-            continue;
-          }
-          // Node-web ReadableStream → Node stream for archiver.append.
-          const entryName = `version_${version.id}_clean.jpg`;
-          const buf = Buffer.from(await r.arrayBuffer());
-          archive.append(buf, { name: entryName });
-        } catch (entryErr: any) {
-          console.warn(
-            `⚠️ PHOTO: Skipping version ${version.id} in zip:`,
-            entryErr?.message
-          );
+      // Fetch and append in bounded-parallel batches. Prior implementation
+      // buffered each file into memory via `arrayBuffer()` and fetched
+      // serially; piping the web-stream straight into archiver keeps
+      // memory bounded, and batching by ZIP_FETCH_CONCURRENCY reduces total
+      // wall-time for large batches while capping connection count to the
+      // storage origin.
+      const ZIP_FETCH_CONCURRENCY = 6;
+      const candidates = plan.alreadyUnlocked.filter((v) => !!v.cleanOutputUrl);
+
+      for (let i = 0; i < candidates.length; i += ZIP_FETCH_CONCURRENCY) {
+        const slice = candidates.slice(i, i + ZIP_FETCH_CONCURRENCY);
+        const fetched = await Promise.all(
+          slice.map(async (version) => {
+            try {
+              const r = await fetch(version.cleanOutputUrl!);
+              if (!r.ok || !r.body) {
+                console.warn(
+                  `⚠️ PHOTO: Skipping version ${version.id} in zip — fetch ${r.status}`
+                );
+                return null;
+              }
+              return {
+                id: version.id,
+                name: `version_${version.id}_clean.jpg`,
+                // Node-web ReadableStream → Node Readable so archiver can
+                // consume it with its own backpressure.
+                stream: Readable.fromWeb(r.body as any),
+              };
+            } catch (entryErr: any) {
+              console.warn(
+                `⚠️ PHOTO: Skipping version ${version.id} in zip:`,
+                entryErr?.message
+              );
+              return null;
+            }
+          })
+        );
+
+        // Append sequentially within the batch — archiver processes one
+        // entry at a time, so sequential append is the natural fit. The
+        // parallelism we care about is kicking off the HTTP fetches
+        // concurrently (above); appending a stream is cheap.
+        for (const entry of fetched) {
+          if (!entry) continue;
+          archive.append(entry.stream, { name: entry.name });
         }
       }
 

--- a/server/routes/photo-routes.ts
+++ b/server/routes/photo-routes.ts
@@ -13,6 +13,7 @@
 
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
+import archiver from "archiver";
 import { z } from "zod";
 import { authenticateToken } from "../middleware/auth";
 import { organizationService } from "../services/organization-service";
@@ -26,7 +27,13 @@ import {
   photoCreditService,
   getPhotoCreditPacks,
   PackNotConfiguredError,
+  InsufficientCreditsError,
 } from "../services/photo-credit-service";
+import {
+  photoDownloadService,
+  NoCleanRenditionError,
+  VersionNotFoundError,
+} from "../services/photo-download-service";
 
 // Uploads are held in memory so we can pipe buffers to Firebase Storage
 // without a disk hop. 25MB per file (pro-camera JPEGs run 8–20MB), up to
@@ -573,6 +580,303 @@ router.post("/credits/checkout", async (req: Request, res: Response) => {
     res.status(500).json({ message: "Failed to start checkout" });
   }
 });
+
+// -----------------------------------------------------------------------------
+// Downloads (Week 6) — pay-on-unlock clean renditions
+// -----------------------------------------------------------------------------
+
+/**
+ * POST /api/photo/projects/:id/versions/:versionId/unlock
+ *
+ * Pay-once-per-version unlock. Debits 1 credit if this org hasn't paid for
+ * this version before, returns the clean (unwatermarked) URL either way.
+ * Idempotent: lost-tab re-unlocks don't re-bill.
+ *
+ * Status codes:
+ *   200 — unlocked (charged=false if already paid, true if freshly debited)
+ *   402 — InsufficientCreditsError (not enough credits; includes balance)
+ *   404 — version not found / not in this org
+ *   409 — version has no clean rendition (pre-Week-6 data)
+ */
+router.post(
+  "/projects/:id/versions/:versionId/unlock",
+  async (req: Request, res: Response) => {
+    const projectId = Number(req.params.id);
+    const versionId = Number(req.params.versionId);
+    if (!Number.isFinite(projectId) || projectId <= 0) {
+      return res.status(400).json({ message: "Invalid project id" });
+    }
+    if (!Number.isFinite(versionId) || versionId <= 0) {
+      return res.status(400).json({ message: "Invalid version id" });
+    }
+    try {
+      // Editor+ required — viewers can see watermarked previews but not unlock.
+      await organizationService.requireMembership(
+        req.user!.id,
+        req.orgId!,
+        "editor"
+      );
+      const project = await photoProjectService.getByIdForOrg(projectId, req.orgId!);
+      if (!project) {
+        return res.status(404).json({ message: "Project not found" });
+      }
+
+      const result = await photoDownloadService.unlock({
+        orgId: req.orgId!,
+        userId: req.user!.id,
+        projectId,
+        versionId,
+      });
+
+      res.json({
+        url: result.cleanUrl,
+        charged: result.charged,
+        downloadId: result.download.id,
+        versionId: result.version.id,
+        balanceAfter: result.balanceAfter,
+      });
+    } catch (error: any) {
+      if (error instanceof InsufficientCreditsError) {
+        return res.status(402).json({
+          message: "Insufficient credits — top up to unlock this version.",
+          required: error.required,
+          available: error.available,
+        });
+      }
+      if (error instanceof VersionNotFoundError) {
+        return res.status(404).json({ message: error.message });
+      }
+      if (error instanceof NoCleanRenditionError) {
+        return res.status(409).json({ message: error.message });
+      }
+      if (error.statusCode) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+      console.error("❌ PHOTO: Unlock failed", error);
+      res.status(500).json({ message: "Unlock failed" });
+    }
+  }
+);
+
+const batchUnlockBody = z.object({
+  versionIds: z.array(z.number().int().positive()).min(1).max(50),
+  /**
+   * When true, we only return the plan (chargeable vs already-unlocked vs
+   * missing vs invalid + total credits required). No debit, no download.
+   * UI uses this to render the confirm dialog.
+   */
+  planOnly: z.boolean().optional(),
+});
+
+/**
+ * POST /api/photo/projects/:id/versions/batch-unlock
+ *
+ * Two modes:
+ *   - planOnly=true: returns { chargeable, alreadyUnlocked, missingClean,
+ *     invalid, creditsNeeded, balance } without touching credits. Safe to
+ *     call on every checkbox change.
+ *   - default: debits credits for the chargeable set and returns
+ *     { unlocked: UnlockResult[], failed?: { reason, required, available } }.
+ *     Partial fulfilment on overdraft — caller can render "you unlocked N
+ *     of M, top up to finish the rest."
+ *
+ * Does NOT stream a ZIP — clients call this to debit, then hit the ZIP
+ * endpoint below with the resulting version ids. Keeping unlock (payment)
+ * and delivery (bytes) separate means a flaky client network doesn't
+ * re-bill.
+ */
+router.post(
+  "/projects/:id/versions/batch-unlock",
+  async (req: Request, res: Response) => {
+    const projectId = Number(req.params.id);
+    if (!Number.isFinite(projectId) || projectId <= 0) {
+      return res.status(400).json({ message: "Invalid project id" });
+    }
+    const parsed = batchUnlockBody.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json({ message: "Invalid request", errors: parsed.error.flatten() });
+    }
+    try {
+      await organizationService.requireMembership(
+        req.user!.id,
+        req.orgId!,
+        "editor"
+      );
+      const project = await photoProjectService.getByIdForOrg(projectId, req.orgId!);
+      if (!project) {
+        return res.status(404).json({ message: "Project not found" });
+      }
+
+      if (parsed.data.planOnly) {
+        const plan = await photoDownloadService.planBatch({
+          orgId: req.orgId!,
+          projectId,
+          versionIds: parsed.data.versionIds,
+        });
+        const balance = await photoCreditService.getBalance(req.orgId!);
+        return res.json({
+          plan: {
+            chargeable: plan.chargeable.map((v) => v.id),
+            alreadyUnlocked: plan.alreadyUnlocked.map((v) => v.id),
+            missingClean: plan.missingClean.map((v) => v.id),
+            invalid: plan.invalid,
+            creditsNeeded: plan.creditsNeeded,
+          },
+          balance,
+        });
+      }
+
+      const { results, insufficient } = await photoDownloadService.unlockBatch({
+        orgId: req.orgId!,
+        userId: req.user!.id,
+        projectId,
+        versionIds: parsed.data.versionIds,
+      });
+
+      const balance = await photoCreditService.getBalance(req.orgId!);
+      res.json({
+        unlocked: results.map((r) => ({
+          versionId: r.version.id,
+          url: r.cleanUrl,
+          charged: r.charged,
+          downloadId: r.download.id,
+        })),
+        failed: insufficient
+          ? {
+              reason: "insufficient_credits",
+              required: insufficient.required,
+              available: insufficient.available,
+            }
+          : undefined,
+        balance,
+      });
+    } catch (error: any) {
+      if (error.statusCode) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+      console.error("❌ PHOTO: Batch unlock failed", error);
+      res.status(500).json({ message: "Batch unlock failed" });
+    }
+  }
+);
+
+/**
+ * GET /api/photo/projects/:id/versions/download.zip?versionIds=1,2,3
+ *
+ * Streams a ZIP of the clean renditions for the given versions. Does NOT
+ * debit — caller must have already called batch-unlock. Versions that have
+ * never been unlocked by this org are skipped (we check photo_downloads).
+ * This split prevents re-billing on browser retry.
+ *
+ * Why GET not POST: browsers download GET responses naturally via
+ * `<a download>` / window.location. POST would force a fetch+Blob dance.
+ * Query-string `versionIds` works fine for the 50-item cap we enforce on
+ * batch-unlock.
+ */
+router.get(
+  "/projects/:id/versions/download.zip",
+  async (req: Request, res: Response) => {
+    const projectId = Number(req.params.id);
+    if (!Number.isFinite(projectId) || projectId <= 0) {
+      return res.status(400).json({ message: "Invalid project id" });
+    }
+
+    const raw = String(req.query.versionIds ?? "");
+    const versionIds = raw
+      .split(",")
+      .map((s) => Number(s.trim()))
+      .filter((n) => Number.isFinite(n) && n > 0);
+    if (versionIds.length === 0) {
+      return res
+        .status(400)
+        .json({ message: "versionIds query param required (comma-separated ints)" });
+    }
+    if (versionIds.length > 50) {
+      return res.status(400).json({ message: "Too many versions — max 50 per zip" });
+    }
+
+    try {
+      const project = await photoProjectService.getByIdForOrg(projectId, req.orgId!);
+      if (!project) {
+        return res.status(404).json({ message: "Project not found" });
+      }
+
+      // Plan tells us which versions are already unlocked AND have a clean
+      // rendition. We only stream those — anything else would require a
+      // debit, which this endpoint deliberately does not do.
+      const plan = await photoDownloadService.planBatch({
+        orgId: req.orgId!,
+        projectId,
+        versionIds,
+      });
+      if (plan.alreadyUnlocked.length === 0) {
+        return res.status(409).json({
+          message:
+            "None of the requested versions have been unlocked yet. Call /versions/batch-unlock first.",
+          invalid: plan.invalid,
+          missingClean: plan.missingClean.map((v) => v.id),
+          chargeable: plan.chargeable.map((v) => v.id),
+        });
+      }
+
+      // Stream the zip. `archiver` pipes straight to the Express response
+      // so memory stays bounded regardless of how many MB we're shipping.
+      res.setHeader("Content-Type", "application/zip");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="ailldoit-project-${projectId}-${Date.now()}.zip"`
+      );
+
+      const archive = archiver("zip", { zlib: { level: 6 } });
+      archive.on("warning", (warn) => {
+        console.warn("⚠️ PHOTO: zip archiver warning", warn);
+      });
+      archive.on("error", (err) => {
+        console.error("❌ PHOTO: zip archiver error", err);
+        // Socket is already streaming — destroy to signal broken zip.
+        res.destroy(err);
+      });
+      archive.pipe(res);
+
+      for (const version of plan.alreadyUnlocked) {
+        if (!version.cleanOutputUrl) continue; // belt-and-braces
+        try {
+          const r = await fetch(version.cleanOutputUrl);
+          if (!r.ok || !r.body) {
+            console.warn(
+              `⚠️ PHOTO: Skipping version ${version.id} in zip — fetch ${r.status}`
+            );
+            continue;
+          }
+          // Node-web ReadableStream → Node stream for archiver.append.
+          const entryName = `version_${version.id}_clean.jpg`;
+          const buf = Buffer.from(await r.arrayBuffer());
+          archive.append(buf, { name: entryName });
+        } catch (entryErr: any) {
+          console.warn(
+            `⚠️ PHOTO: Skipping version ${version.id} in zip:`,
+            entryErr?.message
+          );
+        }
+      }
+
+      await archive.finalize();
+    } catch (error: any) {
+      if (error.statusCode) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+      // If we already flushed headers, we can't send JSON — log and bail.
+      if (res.headersSent) {
+        console.error("❌ PHOTO: zip stream failed mid-flight", error);
+        return res.destroy(error);
+      }
+      console.error("❌ PHOTO: zip download failed", error);
+      res.status(500).json({ message: "Zip download failed" });
+    }
+  }
+);
 
 // -----------------------------------------------------------------------------
 // Current org (debug/inspection — used by client to show workspace name)

--- a/server/scripts/backfill-photo-credits.ts
+++ b/server/scripts/backfill-photo-credits.ts
@@ -30,8 +30,11 @@
  *    auth plumbing we don't need permanently.
  */
 
-import { config } from "dotenv";
-config();
+// IMPORTANT: dotenv/config must be the very first import. ESM imports are
+// evaluated in order, so loading env vars here ensures downstream modules
+// (photo-credit-service → `new Stripe(ENV.stripe.secretKey)` at module
+// level) see the populated process.env.
+import "dotenv/config";
 
 import Stripe from "stripe";
 import { ENV } from "../config/environment";

--- a/server/services/photo-credit-service.ts
+++ b/server/services/photo-credit-service.ts
@@ -33,6 +33,14 @@ import {
   type PhotoCreditLedgerEntry,
 } from "@shared/schema";
 
+/**
+ * Drizzle transaction handle. Services that compose a debit with other
+ * writes (e.g. photo-download-service inserting a `photo_downloads`
+ * receipt) can pass their own `tx` into `chargeForDownload` so the debit
+ * and the receipt either both commit or neither does.
+ */
+export type DbTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
 const stripe = new Stripe(ENV.stripe.secretKey, {
   apiVersion: "2025-08-27.basil",
 });
@@ -219,21 +227,30 @@ export class PhotoCreditService {
    * overdraft — callers should respond 402.
    *
    * `amount` is positive; we write it as a negative delta internally.
+   *
+   * **Transaction composition.** When the caller passes `tx`, the debit
+   * runs inside the caller's transaction — useful when another write
+   * (e.g. the `photo_downloads` receipt) must commit or fail atomically
+   * with the debit. When `tx` is omitted we open our own transaction so
+   * existing call sites keep working unchanged.
    */
-  async chargeForDownload(input: {
-    orgId: string;
-    userId: string;
-    amount: number;
-    refId: string; // photo_download row id (stringified) or version id
-  }): Promise<PhotoCreditLedgerEntry> {
+  async chargeForDownload(
+    input: {
+      orgId: string;
+      userId: string;
+      amount: number;
+      refId: string; // photo_download row id (stringified) or version id
+    },
+    tx?: DbTx
+  ): Promise<PhotoCreditLedgerEntry> {
     if (input.amount <= 0) {
       throw new Error("Debit amount must be positive");
     }
 
-    return db.transaction(async (tx) => {
+    const runWithTx = async (t: DbTx): Promise<PhotoCreditLedgerEntry> => {
       // Lock the most recent row for this org so a concurrent debit waits.
       // SELECT ... FOR UPDATE on a single-row read is the standard pattern.
-      const [latest] = await tx
+      const [latest] = await t
         .select({ balanceAfter: photoCreditLedger.balanceAfter })
         .from(photoCreditLedger)
         .where(eq(photoCreditLedger.orgId, input.orgId))
@@ -247,7 +264,7 @@ export class PhotoCreditService {
       }
 
       const newBalance = currentBalance - input.amount;
-      const [row] = await tx
+      const [row] = await t
         .insert(photoCreditLedger)
         .values({
           orgId: input.orgId,
@@ -262,7 +279,9 @@ export class PhotoCreditService {
         .returning();
 
       return row;
-    });
+    };
+
+    return tx ? runWithTx(tx) : db.transaction(runWithTx);
   }
 
   /**

--- a/server/services/photo-download-service.ts
+++ b/server/services/photo-download-service.ts
@@ -1,0 +1,314 @@
+/**
+ * photo-download-service — pay-on-download delivery.
+ *
+ * Separation of concerns:
+ *   - `photoCreditService` knows how to move credits in and out of the
+ *     ledger.
+ *   - THIS service knows how a "download" maps to credit motion + an
+ *     audit row in `photo_downloads` + a URL the client can GET.
+ *
+ * Two key invariants:
+ *
+ *   1. **Pay once per version per org.** If an org unlocks a version, the
+ *      photo_downloads row is the receipt. Re-unlocking the same version
+ *      from the same org does NOT debit again — we just return the clean
+ *      URL. That makes "lost the tab, come back, download again" free for
+ *      the customer and removes a class of double-billing support
+ *      tickets. Rationale: they already paid; storage is cheap.
+ *
+ *   2. **Debit + receipt insert are transactional.** If the debit
+ *      succeeds but the receipt insert fails (or vice-versa) we'd either
+ *      silently over-bill or let them download for free. Both live in a
+ *      single DB transaction.
+ *
+ * Multi-version batch unlocks compose: we loop single-version unlocks and
+ * the idempotency handles the "already unlocked some" case naturally.
+ * Overdraft: if credits run out mid-batch we surface the first failure
+ * and the rest stay unlocked — we do NOT roll back already-debited rows.
+ * Partial fulfilment is intended: the user got N good downloads and we
+ * tell them to top up for the rest. Cleaner than "all or nothing."
+ */
+
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "../db";
+import {
+  editVersions,
+  photoAssets,
+  photoDownloads,
+  photoProjects,
+  type EditVersion,
+  type PhotoDownload,
+} from "@shared/schema";
+import {
+  InsufficientCreditsError,
+  photoCreditService,
+} from "./photo-credit-service";
+
+export class NoCleanRenditionError extends Error {
+  statusCode = 409;
+  constructor(public versionId: number) {
+    super(
+      `Version ${versionId} has no clean rendition — it was produced before the paid-download feature shipped. Re-run the pipeline to generate one.`
+    );
+    this.name = "NoCleanRenditionError";
+  }
+}
+
+export class VersionNotFoundError extends Error {
+  statusCode = 404;
+  constructor(public versionId: number) {
+    super(`Version ${versionId} not found or does not belong to this org`);
+    this.name = "VersionNotFoundError";
+  }
+}
+
+export interface UnlockResult {
+  version: EditVersion;
+  cleanUrl: string;
+  /** True if this call actually debited credits; false if the org had previously unlocked this version. */
+  charged: boolean;
+  download: PhotoDownload;
+  balanceAfter: number;
+}
+
+/** Credits charged per unlocked version. Flat for MVP; can become
+ * per-resolution or per-feature later without a schema change. */
+const CREDITS_PER_UNLOCK = 1;
+
+export class PhotoDownloadService {
+  /**
+   * Unlock one version: verify tenancy, debit credits if not already
+   * unlocked by this org, return the clean URL.
+   */
+  async unlock(input: {
+    orgId: string;
+    userId: string;
+    projectId: number;
+    versionId: number;
+  }): Promise<UnlockResult> {
+    const version = await this.findVersionInOrg(
+      input.orgId,
+      input.projectId,
+      input.versionId
+    );
+    if (!version) {
+      throw new VersionNotFoundError(input.versionId);
+    }
+    if (!version.cleanOutputUrl) {
+      throw new NoCleanRenditionError(input.versionId);
+    }
+
+    // Idempotency: if this org has already paid for this version, return
+    // the receipt without re-debiting. Scoped by project → org because
+    // photo_downloads doesn't carry an orgId column, but project does.
+    const existing = await this.findExistingDownload(
+      input.projectId,
+      input.versionId
+    );
+    if (existing) {
+      const balanceAfter = await photoCreditService.getBalance(input.orgId);
+      return {
+        version,
+        cleanUrl: version.cleanOutputUrl,
+        charged: false,
+        download: existing,
+        balanceAfter,
+      };
+    }
+
+    // Charge + receipt atomically. chargeForDownload throws
+    // InsufficientCreditsError on overdraft, which the route surfaces
+    // as 402.
+    const ledger = await photoCreditService.chargeForDownload({
+      orgId: input.orgId,
+      userId: input.userId,
+      amount: CREDITS_PER_UNLOCK,
+      refId: String(input.versionId),
+    });
+
+    const [download] = await db
+      .insert(photoDownloads)
+      .values({
+        projectId: input.projectId,
+        userId: input.userId,
+        versionId: input.versionId,
+        creditsCharged: CREDITS_PER_UNLOCK,
+      })
+      .returning();
+
+    return {
+      version,
+      cleanUrl: version.cleanOutputUrl,
+      charged: true,
+      download,
+      balanceAfter: ledger.balanceAfter,
+    };
+  }
+
+  /**
+   * Plan a batch unlock. Returns the versions that will be charged vs.
+   * already-unlocked, so the UI can show an accurate "N credits will be
+   * debited" before confirming. Does NOT debit.
+   */
+  async planBatch(input: {
+    orgId: string;
+    projectId: number;
+    versionIds: number[];
+  }): Promise<{
+    chargeable: EditVersion[];
+    alreadyUnlocked: EditVersion[];
+    missingClean: EditVersion[];
+    invalid: number[];
+    creditsNeeded: number;
+  }> {
+    if (input.versionIds.length === 0) {
+      return {
+        chargeable: [],
+        alreadyUnlocked: [],
+        missingClean: [],
+        invalid: [],
+        creditsNeeded: 0,
+      };
+    }
+    const versions = await this.findVersionsInProject(
+      input.orgId,
+      input.projectId,
+      input.versionIds
+    );
+    const foundIds = new Set(versions.map((v) => v.id));
+    const invalid = input.versionIds.filter((id) => !foundIds.has(id));
+
+    const missingClean = versions.filter((v) => !v.cleanOutputUrl);
+    const withClean = versions.filter((v) => !!v.cleanOutputUrl);
+
+    const previouslyUnlockedIds = new Set(
+      (
+        await db
+          .select({ versionId: photoDownloads.versionId })
+          .from(photoDownloads)
+          .where(
+            and(
+              eq(photoDownloads.projectId, input.projectId),
+              inArray(
+                photoDownloads.versionId,
+                withClean.map((v) => v.id)
+              )
+            )
+          )
+      ).map((r) => r.versionId)
+    );
+
+    const chargeable = withClean.filter((v) => !previouslyUnlockedIds.has(v.id));
+    const alreadyUnlocked = withClean.filter((v) => previouslyUnlockedIds.has(v.id));
+
+    return {
+      chargeable,
+      alreadyUnlocked,
+      missingClean,
+      invalid,
+      creditsNeeded: chargeable.length * CREDITS_PER_UNLOCK,
+    };
+  }
+
+  /**
+   * Execute a batch unlock — one atomic debit loop. Partial fulfilment
+   * on overdraft: versions processed before the InsufficientCreditsError
+   * stay unlocked, the remainder aren't. Caller gets back a list of
+   * UnlockResults + the error so the UI can render "you unlocked N of M,
+   * top up to finish."
+   */
+  async unlockBatch(input: {
+    orgId: string;
+    userId: string;
+    projectId: number;
+    versionIds: number[];
+  }): Promise<{
+    results: UnlockResult[];
+    insufficient?: InsufficientCreditsError;
+  }> {
+    const results: UnlockResult[] = [];
+    for (const versionId of input.versionIds) {
+      try {
+        const result = await this.unlock({
+          orgId: input.orgId,
+          userId: input.userId,
+          projectId: input.projectId,
+          versionId,
+        });
+        results.push(result);
+      } catch (err) {
+        if (err instanceof InsufficientCreditsError) {
+          return { results, insufficient: err };
+        }
+        // NoCleanRenditionError / VersionNotFoundError skip silently in
+        // batch mode — the planner already surfaced them. An unexpected
+        // error bubbles.
+        if (
+          err instanceof VersionNotFoundError ||
+          err instanceof NoCleanRenditionError
+        ) {
+          continue;
+        }
+        throw err;
+      }
+    }
+    return { results };
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Internals — tenancy-checked lookups
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Fetch a version only if it belongs to a project that belongs to the
+   * org. Prevents cross-org version id guessing.
+   */
+  private async findVersionInOrg(
+    orgId: string,
+    projectId: number,
+    versionId: number
+  ): Promise<EditVersion | null> {
+    const rows = await this.findVersionsInProject(orgId, projectId, [versionId]);
+    return rows[0] ?? null;
+  }
+
+  private async findVersionsInProject(
+    orgId: string,
+    projectId: number,
+    versionIds: number[]
+  ): Promise<EditVersion[]> {
+    if (versionIds.length === 0) return [];
+    const rows = await db
+      .select({ version: editVersions })
+      .from(editVersions)
+      .innerJoin(photoAssets, eq(photoAssets.id, editVersions.assetId))
+      .innerJoin(photoProjects, eq(photoProjects.id, photoAssets.projectId))
+      .where(
+        and(
+          eq(photoProjects.orgId, orgId),
+          eq(photoProjects.id, projectId),
+          inArray(editVersions.id, versionIds)
+        )
+      );
+    return rows.map((r) => r.version);
+  }
+
+  private async findExistingDownload(
+    projectId: number,
+    versionId: number
+  ): Promise<PhotoDownload | null> {
+    const [row] = await db
+      .select()
+      .from(photoDownloads)
+      .where(
+        and(
+          eq(photoDownloads.projectId, projectId),
+          eq(photoDownloads.versionId, versionId)
+        )
+      )
+      .limit(1);
+    return row ?? null;
+  }
+}
+
+export const photoDownloadService = new PhotoDownloadService();

--- a/server/services/photo-download-service.ts
+++ b/server/services/photo-download-service.ts
@@ -42,7 +42,23 @@ import {
 import {
   InsufficientCreditsError,
   photoCreditService,
+  type DbTx,
 } from "./photo-credit-service";
+
+/**
+ * Narrow check for Postgres unique-violation errors surfaced through
+ * node-postgres. Drizzle rethrows the driver error; `code` 23505 = unique
+ * violation per Postgres spec. Keeping this typed as `unknown` avoids a
+ * runtime dep on `pg`'s error class.
+ */
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "23505"
+  );
+}
 
 export class NoCleanRenditionError extends Error {
   statusCode = 409;
@@ -79,6 +95,24 @@ export class PhotoDownloadService {
   /**
    * Unlock one version: verify tenancy, debit credits if not already
    * unlocked by this org, return the clean URL.
+   *
+   * Atomicity contract:
+   *   - Tenancy check runs before the transaction — it's read-only and its
+   *     answer doesn't change under concurrent writes (the version's org
+   *     doesn't move).
+   *   - Debit + photo_downloads insert run in ONE db.transaction. Either
+   *     both commit, or neither does. The credit debit can never leave a
+   *     ledger row without a matching receipt.
+   *   - The unique index on (project_id, version_id) turns concurrent
+   *     first-time unlocks into a race where exactly one transaction wins.
+   *     The loser catches 23505, the transaction rolls back (credits
+   *     refunded), and we re-read the winning receipt and return it as a
+   *     free re-unlock.
+   *
+   * The pre-transaction idempotency read is an optimisation (avoids
+   * FOR-UPDATE locking when we already know the receipt exists), not a
+   * correctness guarantee — the unique index is what actually prevents
+   * double-billing.
    */
   async unlock(input: {
     orgId: string;
@@ -98,8 +132,8 @@ export class PhotoDownloadService {
       throw new NoCleanRenditionError(input.versionId);
     }
 
-    // Idempotency: if this org has already paid for this version, return
-    // the receipt without re-debiting. Scoped by project → org because
+    // Fast path: if this org has already paid for this version, return the
+    // receipt without re-debiting. Scoped by project → org because
     // photo_downloads doesn't carry an orgId column, but project does.
     const existing = await this.findExistingDownload(
       input.projectId,
@@ -116,33 +150,64 @@ export class PhotoDownloadService {
       };
     }
 
-    // Charge + receipt atomically. chargeForDownload throws
-    // InsufficientCreditsError on overdraft, which the route surfaces
-    // as 402.
-    const ledger = await photoCreditService.chargeForDownload({
-      orgId: input.orgId,
-      userId: input.userId,
-      amount: CREDITS_PER_UNLOCK,
-      refId: String(input.versionId),
-    });
+    // First-time unlock path. Debit + receipt in one transaction.
+    try {
+      const { download, balanceAfter } = await db.transaction(async (tx) => {
+        const ledger = await photoCreditService.chargeForDownload(
+          {
+            orgId: input.orgId,
+            userId: input.userId,
+            amount: CREDITS_PER_UNLOCK,
+            refId: String(input.versionId),
+          },
+          tx as DbTx
+        );
 
-    const [download] = await db
-      .insert(photoDownloads)
-      .values({
-        projectId: input.projectId,
-        userId: input.userId,
-        versionId: input.versionId,
-        creditsCharged: CREDITS_PER_UNLOCK,
-      })
-      .returning();
+        const [row] = await tx
+          .insert(photoDownloads)
+          .values({
+            projectId: input.projectId,
+            userId: input.userId,
+            versionId: input.versionId,
+            creditsCharged: CREDITS_PER_UNLOCK,
+          })
+          .returning();
 
-    return {
-      version,
-      cleanUrl: version.cleanOutputUrl,
-      charged: true,
-      download,
-      balanceAfter: ledger.balanceAfter,
-    };
+        return { download: row, balanceAfter: ledger.balanceAfter };
+      });
+
+      return {
+        version,
+        cleanUrl: version.cleanOutputUrl,
+        charged: true,
+        download,
+        balanceAfter,
+      };
+    } catch (err) {
+      // Concurrent unlock won the race — the unique index rejected our
+      // insert, the transaction rolled back, and our credit debit was
+      // undone. Re-read the winning receipt and return it as a free
+      // re-unlock, matching the idempotency contract.
+      if (isUniqueViolation(err)) {
+        const winner = await this.findExistingDownload(
+          input.projectId,
+          input.versionId
+        );
+        if (winner) {
+          const balanceAfter = await photoCreditService.getBalance(input.orgId);
+          return {
+            version,
+            cleanUrl: version.cleanOutputUrl,
+            charged: false,
+            download: winner,
+            balanceAfter,
+          };
+        }
+        // If we can't find the winner (shouldn't happen), surface the
+        // original error so the route returns 500 rather than lying.
+      }
+      throw err;
+    }
   }
 
   /**

--- a/server/workers/handlers/correction-common.ts
+++ b/server/workers/handlers/correction-common.ts
@@ -21,7 +21,6 @@
  * exposures). Those own their own orchestration.
  */
 
-import sharp from "sharp";
 import { and, desc, eq } from "drizzle-orm";
 import type {
   EditJob,
@@ -37,6 +36,7 @@ import {
 } from "@shared/schema";
 import { firebaseStorageService } from "../../services/firebase-storage-service";
 import type { HandlerResult } from "./pipeline-auto";
+import { renderDualOutput } from "./watermark";
 
 /**
  * What a handler must produce given the input. Either a buffer of the
@@ -87,41 +87,49 @@ export async function runSingleAssetCorrection(
     );
   }
 
-  // 2. Produce the corrected buffer. Cost/meta are optional — CPU fallbacks
-  //    typically return 0.
+  // 2. Produce the clean buffer from the handler's produce() callback.
+  //    Every caller (correction handlers, enhance) returns unwatermarked
+  //    bytes here — we do the watermarking uniformly below.
   const produced = await opts.produce({ inputAsset, job });
-  const outputBuffer = produced.outputBuffer;
   const costCents = produced.costCents ?? 0;
   const providerMeta = produced.providerMeta ?? { provider: "local-fallback" };
 
-  // 3. Upload under a stage-aware path so ops can see what's what when
-  //    browsing the bucket.
-  const storagePath = `photo/${inferOrgId(inputAsset)}/${job.projectId}/${opts.stage}/asset_${inputAsset.id}_${Date.now()}_preview.jpg`;
-  const outputUrl = await firebaseStorageService.uploadFile(
-    storagePath,
-    outputBuffer,
-    "image/jpeg",
-    {
+  // 3. Fork into clean + watermarked JPEGs. The clean one backs the paid
+  //    unlock-download; the watermarked one is the free preview. Both
+  //    upload in parallel so latency is ~max(upload_clean, upload_wm)
+  //    rather than sum.
+  const dual = await renderDualOutput(produced.outputBuffer);
+
+  const baseDir = `photo/${inferOrgId(inputAsset)}/${job.projectId}/${opts.stage}`;
+  const stamp = Date.now();
+  const previewPath = `${baseDir}/asset_${inputAsset.id}_${stamp}_preview.jpg`;
+  const cleanPath = `${baseDir}/asset_${inputAsset.id}_${stamp}_clean.jpg`;
+
+  const [outputUrl, cleanOutputUrl] = await Promise.all([
+    firebaseStorageService.uploadFile(previewPath, dual.watermarked, "image/jpeg", {
       editJobId: String(job.id),
       sourceAssetId: String(inputAsset.id),
       kind: `${opts.stage}_preview`,
-    }
-  );
+    }),
+    firebaseStorageService.uploadFile(cleanPath, dual.clean, "image/jpeg", {
+      editJobId: String(job.id),
+      sourceAssetId: String(inputAsset.id),
+      kind: `${opts.stage}_clean`,
+    }),
+  ]);
 
   // 4. Version + asset insert, atomically with demotion of the previous
   //    current version.
   const result = await db.transaction(async (tx) => {
-    const meta = await sharp(outputBuffer).metadata();
-
     const insertAsset: InsertPhotoAsset = {
       projectId: job.projectId,
       userId: job.userId,
-      sourceUrl: outputUrl,
+      sourceUrl: outputUrl, // asset sourceUrl tracks the preview (UI default)
       fileName: `asset_${inputAsset.id}_${opts.stage}.jpg`,
       mimeType: "image/jpeg",
-      sizeBytes: outputBuffer.byteLength,
-      widthPx: meta.width ?? null,
-      heightPx: meta.height ?? null,
+      sizeBytes: dual.watermarked.byteLength,
+      widthPx: dual.width,
+      heightPx: dual.height,
       exifData: null,
       derivedFromJobId: job.id,
     };
@@ -157,6 +165,7 @@ export async function runSingleAssetCorrection(
       jobId: job.id,
       versionNumber: nextVersion,
       outputUrl,
+      cleanOutputUrl,
       watermarked: true,
       isCurrent: true,
     };

--- a/server/workers/handlers/enhance.ts
+++ b/server/workers/handlers/enhance.ts
@@ -40,6 +40,7 @@ import {
   ProviderUnavailableError,
 } from "../../services/photo-providers";
 import type { HandlerResult } from "./pipeline-auto";
+import { renderDualOutput } from "./watermark";
 
 /** Sharpening / vibrance strength used by the local fallback. */
 const LOCAL_SATURATION_LIFT = 1.08;
@@ -89,35 +90,41 @@ export async function handleEnhance(job: EditJob): Promise<HandlerResult> {
     outputBuffer = await localEnhance(inputAsset.sourceUrl);
   }
 
-  // 3. Upload the polished JPEG under a deterministic path.
-  const storagePath = `photo/${inferOrgId(inputAsset)}/${job.projectId}/enhanced/asset_${inputAsset.id}_${Date.now()}_preview.jpg`;
-  const outputUrl = await firebaseStorageService.uploadFile(
-    storagePath,
-    outputBuffer,
-    "image/jpeg",
-    {
+  // 3. Fork the polished buffer into clean + watermarked JPEGs and upload
+  //    both. Clean backs the paid unlock-download; watermarked is the
+  //    free preview shown in the UI.
+  const dual = await renderDualOutput(outputBuffer);
+
+  const baseDir = `photo/${inferOrgId(inputAsset)}/${job.projectId}/enhanced`;
+  const stamp = Date.now();
+  const previewPath = `${baseDir}/asset_${inputAsset.id}_${stamp}_preview.jpg`;
+  const cleanPath = `${baseDir}/asset_${inputAsset.id}_${stamp}_clean.jpg`;
+
+  const [outputUrl, cleanOutputUrl] = await Promise.all([
+    firebaseStorageService.uploadFile(previewPath, dual.watermarked, "image/jpeg", {
       editJobId: String(job.id),
       sourceAssetId: String(inputAsset.id),
       kind: "enhance_preview",
-    }
-  );
+    }),
+    firebaseStorageService.uploadFile(cleanPath, dual.clean, "image/jpeg", {
+      editJobId: String(job.id),
+      sourceAssetId: String(inputAsset.id),
+      kind: "enhance_clean",
+    }),
+  ]);
 
   // 4. Persist the new version. We bump versionNumber relative to the
   //    highest existing version for this asset, and flip isCurrent over.
   const result = await db.transaction(async (tx) => {
-    // Capture image metadata from the buffer once so both the asset row
-    // and the DB match what's actually on disk.
-    const meta = await sharp(outputBuffer).metadata();
-
     const insertAsset: InsertPhotoAsset = {
       projectId: job.projectId,
       userId: job.userId,
       sourceUrl: outputUrl,
       fileName: `asset_${inputAsset.id}_enhanced.jpg`,
       mimeType: "image/jpeg",
-      sizeBytes: outputBuffer.byteLength,
-      widthPx: meta.width ?? null,
-      heightPx: meta.height ?? null,
+      sizeBytes: dual.watermarked.byteLength,
+      widthPx: dual.width,
+      heightPx: dual.height,
       exifData: null,
       derivedFromJobId: job.id,
     };
@@ -154,6 +161,7 @@ export async function handleEnhance(job: EditJob): Promise<HandlerResult> {
       jobId: job.id,
       versionNumber: nextVersion,
       outputUrl,
+      cleanOutputUrl,
       watermarked: true,
       isCurrent: true,
     };

--- a/server/workers/handlers/hdr-merge.ts
+++ b/server/workers/handlers/hdr-merge.ts
@@ -34,6 +34,7 @@ import {
 } from "@shared/schema";
 import { firebaseStorageService } from "../../services/firebase-storage-service";
 import type { HandlerResult } from "./pipeline-auto";
+import { cleanFromRaw, watermarkFromRaw } from "./watermark";
 
 /** Longest-side pixels for the watermarked preview. */
 const PREVIEW_MAX_EDGE = 1920;
@@ -97,26 +98,43 @@ export async function handleHdrMerge(job: EditJob): Promise<HandlerResult> {
   // 3. Mertens-style weighted fusion, single scale.
   const merged = fuseExposures(exposures, width, height, channels);
 
-  // 4. Encode + watermark.
-  const watermarked = await sharp(merged, {
-    raw: { width, height, channels: channels as 3 },
-  })
-    .composite([{ input: watermarkSvg(width, height), top: 0, left: 0 }])
-    .jpeg({ quality: PREVIEW_JPEG_QUALITY, mozjpeg: true })
-    .toBuffer();
+  // 4. Encode both a clean and a watermarked JPEG from the same raw
+  //    fusion buffer. Clean = paid unlock-download, watermarked = free
+  //    preview. Done in parallel so we pay max(encode) not sum.
+  const [cleanBuffer, watermarkedBuffer] = await Promise.all([
+    cleanFromRaw(merged, width, height, channels as 3, {
+      jpegQuality: PREVIEW_JPEG_QUALITY,
+    }),
+    watermarkFromRaw(merged, width, height, channels as 3, {
+      jpegQuality: PREVIEW_JPEG_QUALITY,
+    }),
+  ]);
 
-  // 5. Upload to Firebase Storage under a deterministic preview path.
-  const storagePath = `photo/${inferOrgId(members[0])}/${job.projectId}/merged/bracket_${group.id}_${Date.now()}_preview.jpg`;
-  const outputUrl = await firebaseStorageService.uploadFile(
-    storagePath,
-    watermarked,
-    "image/jpeg",
-    {
+  // 5. Upload both to Firebase Storage under deterministic paths. Again
+  //    parallel; one is for UI preview, the other sits idle until a
+  //    paid unlock requests it.
+  const baseDir = `photo/${inferOrgId(members[0])}/${job.projectId}/merged`;
+  const stamp = Date.now();
+  const previewPath = `${baseDir}/bracket_${group.id}_${stamp}_preview.jpg`;
+  const cleanPath = `${baseDir}/bracket_${group.id}_${stamp}_clean.jpg`;
+
+  const [outputUrl, cleanOutputUrl] = await Promise.all([
+    firebaseStorageService.uploadFile(
+      previewPath,
+      watermarkedBuffer,
+      "image/jpeg",
+      {
+        editJobId: String(job.id),
+        bracketGroupId: String(group.id),
+        kind: "hdr_preview",
+      }
+    ),
+    firebaseStorageService.uploadFile(cleanPath, cleanBuffer, "image/jpeg", {
       editJobId: String(job.id),
       bracketGroupId: String(group.id),
-      kind: "hdr_preview",
-    }
-  );
+      kind: "hdr_clean",
+    }),
+  ]);
 
   // 6. Persist: derived photo_asset + edit_version + update group status.
   const result = await db.transaction(async (tx) => {
@@ -126,7 +144,7 @@ export async function handleHdrMerge(job: EditJob): Promise<HandlerResult> {
       sourceUrl: outputUrl,
       fileName: `bracket_${group.id}_hdr_preview.jpg`,
       mimeType: "image/jpeg",
-      sizeBytes: watermarked.byteLength,
+      sizeBytes: watermarkedBuffer.byteLength,
       widthPx: width,
       heightPx: height,
       exifData: null,
@@ -139,6 +157,7 @@ export async function handleHdrMerge(job: EditJob): Promise<HandlerResult> {
       jobId: job.id,
       versionNumber: 1,
       outputUrl,
+      cleanOutputUrl,
       watermarked: true,
       isCurrent: true,
     };
@@ -286,34 +305,5 @@ function clamp255(v: number): number {
   return Math.round(v);
 }
 
-/**
- * Diagonal "AILLDOIT PREVIEW" watermark. SVG so the text stays crisp at
- * any preview resolution, semi-transparent so the underlying image is
- * clearly visible.
- */
-function watermarkSvg(width: number, height: number): Buffer {
-  const fontSize = Math.max(28, Math.round(Math.min(width, height) * 0.045));
-  const cx = width / 2;
-  const cy = height / 2;
-  return Buffer.from(
-    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
-      <g transform="rotate(-24 ${cx} ${cy})">
-        <text
-          x="${cx}"
-          y="${cy}"
-          font-family="Helvetica, Arial, sans-serif"
-          font-size="${fontSize}"
-          font-weight="700"
-          letter-spacing="8"
-          fill="white"
-          fill-opacity="0.28"
-          stroke="black"
-          stroke-opacity="0.18"
-          stroke-width="2"
-          text-anchor="middle"
-          dominant-baseline="middle"
-        >AILLDOIT PREVIEW</text>
-      </g>
-    </svg>`
-  );
-}
+// Watermark SVG + composite helpers live in ./watermark.ts now, shared
+// across every handler that emits preview renditions.

--- a/server/workers/handlers/watermark.ts
+++ b/server/workers/handlers/watermark.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared watermarking helper for photo pipeline handlers.
+ *
+ * Why this is its own module:
+ *  - Every handler that produces a preview rendition needs to emit BOTH a
+ *    watermarked image (the free preview shown in the UI) AND a clean
+ *    image (the paid unlock-download). Until Week 6 the watermark was
+ *    inlined in hdr-merge only — other handlers (correction, enhance) set
+ *    `watermarked: true` in the DB but uploaded clean buffers, which was
+ *    a bug: users were effectively getting a preview of the unwatermarked
+ *    asset for free.
+ *  - Centralising it here means every handler enforces the same watermark
+ *    (same text, same style) and keeps the two-output contract consistent.
+ *
+ * What "watermarking" means here
+ *  - A diagonal "AILLDOIT PREVIEW" text composited over the image via
+ *    Sharp's composite() + an SVG input. SVG so the text stays crisp at
+ *    any resolution. Semi-transparent white fill + black stroke so it
+ *    shows on both dark and light photos.
+ */
+
+import sharp from "sharp";
+
+/** JPEG quality used for both clean and watermarked output. */
+const DEFAULT_JPEG_QUALITY = 82;
+
+/**
+ * Produce the watermark SVG sized for a given output.
+ * Exported so HDR-merge can still composite onto a raw pixel buffer
+ * without having to re-encode first.
+ */
+export function watermarkSvg(width: number, height: number): Buffer {
+  const fontSize = Math.max(28, Math.round(Math.min(width, height) * 0.045));
+  const cx = width / 2;
+  const cy = height / 2;
+  return Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <g transform="rotate(-24 ${cx} ${cy})">
+        <text
+          x="${cx}"
+          y="${cy}"
+          font-family="Helvetica, Arial, sans-serif"
+          font-size="${fontSize}"
+          font-weight="700"
+          letter-spacing="8"
+          fill="white"
+          fill-opacity="0.28"
+          stroke="black"
+          stroke-opacity="0.18"
+          stroke-width="2"
+          text-anchor="middle"
+          dominant-baseline="middle"
+        >AILLDOIT PREVIEW</text>
+      </g>
+    </svg>`
+  );
+}
+
+export interface DualOutput {
+  /** Clean JPEG — served only after credits have been debited. */
+  clean: Buffer;
+  /** Watermarked JPEG — free preview. */
+  watermarked: Buffer;
+  width: number;
+  height: number;
+}
+
+/**
+ * Given a clean input buffer (output of a provider or CPU handler),
+ * produce both the clean and the watermarked JPEGs ready for upload.
+ *
+ * Encoding happens twice: once for the clean output (just normalise +
+ * re-encode at controlled quality), once with the watermark composite.
+ * We could save the first encode by returning the source buffer
+ * untouched, but we re-encode so the two outputs share dimensions and
+ * quality settings (important for perceptual parity between preview
+ * and paid version).
+ */
+export async function renderDualOutput(
+  sourceBuffer: Buffer,
+  opts?: { jpegQuality?: number }
+): Promise<DualOutput> {
+  const quality = opts?.jpegQuality ?? DEFAULT_JPEG_QUALITY;
+
+  // First pass: produce the clean buffer + capture dimensions. We
+  // honour EXIF rotation here so the watermark aligns correctly — Sharp
+  // otherwise respects the orientation flag without baking it in.
+  const baseline = sharp(sourceBuffer, { failOn: "none" }).rotate();
+  const { data: cleanData, info } = await baseline
+    .jpeg({ quality, mozjpeg: true })
+    .toBuffer({ resolveWithObject: true });
+
+  // Second pass: composite the watermark over a fresh pipeline reading
+  // the *clean* buffer we just produced. We don't reuse the Sharp
+  // instance above because .toBuffer() finalises it.
+  const watermarked = await sharp(cleanData, { failOn: "none" })
+    .composite([
+      { input: watermarkSvg(info.width, info.height), top: 0, left: 0 },
+    ])
+    .jpeg({ quality, mozjpeg: true })
+    .toBuffer();
+
+  return {
+    clean: Buffer.from(cleanData),
+    watermarked,
+    width: info.width,
+    height: info.height,
+  };
+}
+
+/**
+ * Composite a watermark onto raw RGB pixel data (used by HDR-merge
+ * which already has an in-memory raw buffer from the Mertens fusion).
+ * Returns a watermarked JPEG. The caller is responsible for separately
+ * producing the clean JPEG from the same raw buffer.
+ */
+export async function watermarkFromRaw(
+  raw: Buffer,
+  width: number,
+  height: number,
+  channels: 3 | 4,
+  opts?: { jpegQuality?: number }
+): Promise<Buffer> {
+  const quality = opts?.jpegQuality ?? DEFAULT_JPEG_QUALITY;
+  return sharp(raw, { raw: { width, height, channels } })
+    .composite([{ input: watermarkSvg(width, height), top: 0, left: 0 }])
+    .jpeg({ quality, mozjpeg: true })
+    .toBuffer();
+}
+
+/**
+ * Encode a raw RGB buffer as a clean JPEG without watermark. Pair with
+ * `watermarkFromRaw` so HDR-merge can emit both outputs from a single
+ * fusion pass.
+ */
+export async function cleanFromRaw(
+  raw: Buffer,
+  width: number,
+  height: number,
+  channels: 3 | 4,
+  opts?: { jpegQuality?: number }
+): Promise<Buffer> {
+  const quality = opts?.jpegQuality ?? DEFAULT_JPEG_QUALITY;
+  return sharp(raw, { raw: { width, height, channels } })
+    .jpeg({ quality, mozjpeg: true })
+    .toBuffer();
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -407,6 +407,12 @@ export const editVersions = pgTable("edit_versions", {
   jobId: integer("job_id").references(() => editJobs.id, { onDelete: "set null" }),
   versionNumber: integer("version_number").notNull(),
   outputUrl: text("output_url").notNull(),
+  // Clean (unwatermarked) rendition, produced in parallel with `outputUrl`
+  // at handler time and uploaded to a distinct Firebase path. The unlock-
+  // download endpoint returns this URL after debiting credits. Nullable
+  // because legacy rows (pre-Week-6) don't have a clean variant — those
+  // versions can't be unlocked without re-running the pipeline.
+  cleanOutputUrl: text("clean_output_url"),
   watermarked: boolean("watermarked").default(true),
   isCurrent: boolean("is_current").default(false),
   createdAt: timestamp("created_at").defaultNow(),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, boolean, timestamp, json, varchar, index } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, boolean, timestamp, json, varchar, index, uniqueIndex } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 import { sql } from 'drizzle-orm';
@@ -419,16 +419,32 @@ export const editVersions = pgTable("edit_versions", {
 });
 
 // Pay-on-download events. Drives billing; rows here = revenue events.
-export const photoDownloads = pgTable("photo_downloads", {
-  id: serial("id").primaryKey(),
-  projectId: integer("project_id").references(() => photoProjects.id).notNull(),
-  userId: varchar("user_id").references(() => users.id).notNull(),
-  versionId: integer("version_id").references(() => editVersions.id).notNull(),
-  creditsCharged: integer("credits_charged").notNull().default(1),
-  stripePaymentIntentId: text("stripe_payment_intent_id"),
-  downloadedAt: timestamp("downloaded_at").defaultNow(),
-  createdAt: timestamp("created_at").defaultNow(),
-});
+//
+// Unique on (project_id, version_id): we charge once per org per version.
+// The service-level idempotency check is a belt; this DB constraint is the
+// braces — if two concurrent unlock requests both pass the "not yet unlocked"
+// check and race to insert, exactly one wins, the other surfaces a 23505
+// violation and the transaction rolls back (reversing the credit debit).
+// Without this, double-billing is latent.
+export const photoDownloads = pgTable(
+  "photo_downloads",
+  {
+    id: serial("id").primaryKey(),
+    projectId: integer("project_id").references(() => photoProjects.id).notNull(),
+    userId: varchar("user_id").references(() => users.id).notNull(),
+    versionId: integer("version_id").references(() => editVersions.id).notNull(),
+    creditsCharged: integer("credits_charged").notNull().default(1),
+    stripePaymentIntentId: text("stripe_payment_intent_id"),
+    downloadedAt: timestamp("downloaded_at").defaultNow(),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("photo_downloads_project_version_uniq").on(
+      table.projectId,
+      table.versionId
+    ),
+  ]
+);
 
 // Saved per-user adjustment preferences ("Style Preferences" in AutoHDR parlance).
 // Lets an account apply consistent looks across shoots.


### PR DESCRIPTION
## Summary
- Adds the paid unlock path end-to-end: `photoDownloadService` with
  atomic debit + `photo_downloads` receipt, idempotent per org+version,
  partial-fulfilment on overdraft
- Dual-output pipeline: every handler now emits a clean + watermarked
  JPEG in parallel, so "unlock" is a DB flip + credit debit + signed
  URL — zero AI re-run at pay time
- Client UI: per-version **Unlock (1 credit)** button, free
  **Preview** download, project-header **Download all clean** with
  plan/confirm dialog and streaming ZIP

## Endpoints
- `POST /api/photo/projects/:id/versions/:versionId/unlock`
  (402 / 404 / 409 typed errors)
- `POST /api/photo/projects/:id/versions/batch-unlock` (with `planOnly`)
- `GET  /api/photo/projects/:id/versions/download.zip?versionIds=…`
  (streams via `archiver`)

## Key design calls
- Unlock (payment) is split from ZIP download (delivery) so a flaky
  browser retry never re-bills
- Idempotency keyed on `(project_id, version_id)` — lost-tab
  re-downloads are free
- Partial fulfilment on mid-batch overdraft; UI renders "unlocked N of
  M, top up for the rest"

## Deferred to Week 7
- "Mark project delivered" flag
- Project archive filters

## Test plan
- [ ] Unlock happy path — 1 credit debited, blob downloads as
      `{filename}-clean.jpg`, balance chip updates
- [ ] Re-click same version — no debit, "Already unlocked" toast,
      clean file downloads again
- [ ] Insufficient credits — 402 → top-up dialog, no partial charge
- [ ] Batch plan — dialog shows correct
      `chargeable / alreadyUnlocked / missingClean` split
- [ ] Batch download — ZIP opens, contains one entry per unlocked
      version, filename is `version_{id}_clean.jpg`
- [ ] Partial fulfilment — unlock 10 with 3 credits, get 3 unlocked +
      402, ZIP contains the 3
- [ ] Pre-Week-6 version (null `cleanOutputUrl`) — button disabled
      with "No clean rendition"
- [ ] Free preview download still works for watermarked