### PR TITLE
Week 7 hotfix: Byte-scan fallback for CR3 preview extraction

### DIFF
--- a/server/services/photo-asset-service.ts
+++ b/server/services/photo-asset-service.ts
@@ -22,6 +22,7 @@
  */
 
 import exifr from "exifr";
+import sharp from "sharp";
 import { asc, eq } from "drizzle-orm";
 import { db } from "../db";
 import {
@@ -54,31 +55,131 @@ function isRawFilename(name: string): boolean {
 }
 
 /**
- * Pull the largest embedded JPEG preview out of a RAW file. Most cameras
- * write a full-resolution JPEG inside the RAW container for in-camera
- * review — exifr surfaces it via the `thumbnail` extractor. For MVP this
- * gives us a listing-quality image without needing a native demosaicer.
+ * Scan a buffer for all embedded JPEG images, return them ranked by
+ * decoded width (largest first). This is a format-agnostic fallback
+ * that works for any RAW container — CR3 (ISOBMFF), CR2 (TIFF), DNG
+ * (TIFF), NEF, ARW, RAF all embed one or more JPEGs inside the file.
  *
- * Returns the JPEG buffer, or null if no preview could be extracted.
+ * CR3 specifically: Canon's newer format uses an MP4/ISOBMFF container
+ * that exifr's TIFF-oriented `thumbnail()` can't parse. But the
+ * embedded preview is still just a contiguous JPEG chunk in the buffer,
+ * so a byte-level scan finds it reliably.
+ *
+ * Returns an array of candidate JPEG buffers, largest byte-length first.
+ * Callers are expected to validate each with sharp before trusting it.
+ */
+function findEmbeddedJpegs(buffer: Buffer): Buffer[] {
+  const candidates: Array<{ start: number; end: number }> = [];
+  let i = 0;
+  const len = buffer.length;
+
+  // Scan for every JPEG SOI marker (FF D8 FF). The third byte guards
+  // against random FF D8 pairs in sensor data — real JPEG SOIs are
+  // always followed by another marker byte.
+  while (i < len - 3) {
+    if (
+      buffer[i] === 0xff &&
+      buffer[i + 1] === 0xd8 &&
+      buffer[i + 2] === 0xff
+    ) {
+      // Found a potential SOI. Scan forward for the matching EOI
+      // (FF D9). JPEGs can contain FF D9 inside compressed data, but
+      // the one that ends the file is always followed by either the
+      // end of buffer or a box boundary (in ISOBMFF, 4 zero bytes, or
+      // another SOI marker).
+      let j = i + 3;
+      let lastCandidateEOI = -1;
+      while (j < len - 1) {
+        if (buffer[j] === 0xff && buffer[j + 1] === 0xd9) {
+          lastCandidateEOI = j;
+          // Peek ahead: if the next non-padding bytes look like
+          // another SOI or a box header, this EOI is the real end.
+          const nextIdx = j + 2;
+          if (nextIdx >= len - 2) break;
+          if (
+            buffer[nextIdx] === 0xff &&
+            buffer[nextIdx + 1] === 0xd8 &&
+            buffer[nextIdx + 2] === 0xff
+          ) {
+            break;
+          }
+          // Also break on long runs of FF padding which usually mark
+          // the end of a JPEG segment in RAW containers.
+          if (buffer[nextIdx] === 0x00 && buffer[nextIdx + 1] === 0x00) {
+            break;
+          }
+        }
+        j++;
+      }
+      if (lastCandidateEOI > 0) {
+        candidates.push({ start: i, end: lastCandidateEOI + 2 });
+        i = lastCandidateEOI + 2;
+        continue;
+      }
+    }
+    i++;
+  }
+
+  // Slice out each candidate and sort by byte length, largest first.
+  return candidates
+    .map((c) => buffer.subarray(c.start, c.end))
+    .sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Pull the largest embedded JPEG preview out of a RAW file. Two-stage:
+ *   1. exifr.thumbnail() — works for TIFF-based RAW (CR2/DNG/NEF/ARW).
+ *   2. Byte-level scan — works for CR3 (ISOBMFF) and as a universal
+ *      fallback when exifr's thumbnail box is missing or undersized.
+ *
+ * Each candidate is validated by decoding its metadata with sharp —
+ * that catches false positives from the byte scan (e.g. a thumbnail
+ * segment hiding inside a larger JPEG's EXIF blob).
+ *
+ * Returns the JPEG buffer, or null if no usable preview could be extracted.
  */
 async function extractRawPreview(buffer: Buffer): Promise<Buffer | null> {
+  // Stage 1: exifr fast path. Cheap and correct for most formats.
   try {
     const preview = await exifr.thumbnail(buffer);
-    if (!preview) return null;
-    const asBuffer = Buffer.from(preview);
-    if (asBuffer.length < MIN_PREVIEW_BYTES) {
-      // Some bodies only embed a tiny 160×120 thumbnail — not worth
-      // shipping through the pipeline.
-      return null;
+    if (preview) {
+      const asBuffer = Buffer.from(preview);
+      if (asBuffer.length >= MIN_PREVIEW_BYTES) {
+        return asBuffer;
+      }
     }
-    return asBuffer;
   } catch (err: any) {
+    // Not fatal — fall through to the byte scan. exifr throws on CR3
+    // because it doesn't grok the ISOBMFF container, and that's fine.
     console.warn(
-      "⚠️ PHOTO ASSET: RAW preview extraction failed:",
+      "⚠️ PHOTO ASSET: exifr thumbnail failed, falling back to scan:",
       err?.message
     );
-    return null;
   }
+
+  // Stage 2: byte scan. Walks the whole buffer for JPEG SOI/EOI pairs
+  // and returns candidates largest-first.
+  const candidates = findEmbeddedJpegs(buffer);
+  for (const candidate of candidates) {
+    if (candidate.length < MIN_PREVIEW_BYTES) break; // sorted largest-first
+    try {
+      // sharp validates the JPEG by reading its header. Any well-formed
+      // embedded preview decodes here; thumbnail-sized APP1/APP2 blobs
+      // typically fail or report tiny dimensions.
+      const meta = await sharp(candidate).metadata();
+      if (
+        meta.format === "jpeg" &&
+        (meta.width ?? 0) >= 800 &&
+        (meta.height ?? 0) >= 600
+      ) {
+        return candidate;
+      }
+    } catch {
+      // Not a valid JPEG — keep scanning.
+    }
+  }
+
+  return null;
 }
 
 export interface UploadedFile {


### PR DESCRIPTION
Real-world CR3 uploads (Canon R5/R6 bodies — KL4A9116.CR3 etc.) all failed with "Could not extract a preview" because exifr.thumbnail() only knows TIFF-based RAW containers. CR3 uses ISOBMFF (MP4-style boxes) which exifr can't parse, so it returns null.

Fix: keep exifr as the fast path for TIFF-based RAW (CR2/DNG/NEF/ARW where it Just Works), then fall back to a format-agnostic byte scan that finds every embedded JPEG SOI/EOI pair in the buffer, validates each candidate with sharp, and returns the largest valid one (>= 800×600).

Why this works: every modern camera embeds a full-resolution JPEG preview inside the RAW for in-camera review, and it's stored as a contiguous JPEG chunk regardless of container format. Scanning the raw bytes is cruder than parsing the container, but it's universal — it'll pick up CR3, CR2, DNG, NEF, ARW, RAF, and anything else that embeds a JPEG preview.

Validation step (sharp .metadata()) prevents false positives from thumbnail segments hiding inside a JPEG's APP1/APP2 blocks — we only return candidates that decode as real ≥800px JPEGs.

Verified with a synthetic buffer containing a small thumb JPEG + larger preview JPEG + surrounding junk bytes: scanner correctly returns the 1600×1200 preview as the top candidate and discards the 160×120 thumbnail.