### PR TITLE
Fix: Widen bracket time window + add EXIF diagnostic endpoint

### DIFF
--- a/server/routes/photo-routes.ts
+++ b/server/routes/photo-routes.ts
@@ -413,6 +413,84 @@ router.post(
   }
 );
 
+/**
+ * GET /api/photo/projects/:id/exif-diagnostic
+ * Dumps the parsed EXIF fields used by bracket detection for every asset
+ * in a project. Internal tool — no mutation, no secrets. Lets us see at a
+ * glance whether captureTime parsed correctly and where clustering would
+ * put each photo.
+ */
+router.get(
+  "/projects/:id/exif-diagnostic",
+  async (req: Request, res: Response) => {
+    const projectId = Number(req.params.id);
+    if (!Number.isFinite(projectId) || projectId <= 0) {
+      return res.status(400).json({ message: "Invalid project id" });
+    }
+    try {
+      const project = await photoProjectService.getByIdForOrg(
+        projectId,
+        req.orgId!
+      );
+      if (!project) {
+        return res.status(404).json({ message: "Project not found" });
+      }
+      const assets = await photoAssetService.listByProject(projectId);
+      const rows = assets.map((a) => {
+        const exif = a.exifData as {
+          captureTime?: string | null;
+          exposureBiasEv?: number | null;
+          exposureTimeSec?: number | null;
+          iso?: number | null;
+          cameraModel?: string | null;
+        } | null;
+        return {
+          id: a.id,
+          fileName: a.fileName,
+          bracketGroupId: a.bracketGroupId,
+          captureTime: exif?.captureTime ?? null,
+          captureTimeMs: exif?.captureTime
+            ? new Date(exif.captureTime).getTime()
+            : null,
+          exposureBiasEv: exif?.exposureBiasEv ?? null,
+          exposureTimeSec: exif?.exposureTimeSec ?? null,
+          iso: exif?.iso ?? null,
+          cameraModel: exif?.cameraModel ?? null,
+        };
+      });
+      // Sort by captureTime to make gaps easy to read. Null-captureTime
+      // rows bubble to the top so they're loud.
+      rows.sort((a, b) => {
+        if (a.captureTimeMs == null) return -1;
+        if (b.captureTimeMs == null) return 1;
+        return a.captureTimeMs - b.captureTimeMs;
+      });
+      // Compute the gap (seconds) between each consecutive pair so you
+      // can see at a glance whether TIME_WINDOW_SEC would cluster them.
+      const rowsWithGaps = rows.map((r, i) => {
+        if (i === 0 || rows[i - 1].captureTimeMs == null || r.captureTimeMs == null) {
+          return { ...r, gapToPrevSec: null };
+        }
+        return {
+          ...r,
+          gapToPrevSec:
+            Math.round(((r.captureTimeMs - rows[i - 1].captureTimeMs!) / 1000) * 100) / 100,
+        };
+      });
+      res.json({
+        projectId,
+        assetCount: rows.length,
+        withCaptureTime: rows.filter((r) => r.captureTime).length,
+        withoutCaptureTime: rows.filter((r) => !r.captureTime).length,
+        assets: rowsWithGaps,
+      });
+    } catch (error: any) {
+      console.error("❌ PHOTO: EXIF diagnostic failed", error);
+      res.status(500).json({ message: "EXIF diagnostic failed" });
+    }
+  }
+);
+
 // -----------------------------------------------------------------------------
 // Jobs (BullMQ roundtrip)
 // -----------------------------------------------------------------------------

--- a/server/services/bracket-detection-service.ts
+++ b/server/services/bracket-detection-service.ts
@@ -27,8 +27,17 @@ import {
   type PhotoAsset,
 } from "@shared/schema";
 
-/** Max gap between adjacent frames to still count as the same bracket set. */
-const TIME_WINDOW_SEC = 2.5;
+/**
+ * Max gap between adjacent frames to still count as the same bracket set.
+ *
+ * 6 seconds is a compromise: Canon/Sony AEB bursts fire within ~0.3s, but
+ * photographers doing manual brackets on a tripod (especially for tricky
+ * real-estate interiors) sometimes wait 2–4s between shots to let the
+ * mirror settle. A 2.5s window was clustering bursts correctly but
+ * missing every manual bracket. 6s still rejects unrelated scenes — the
+ * next shot is almost always >10s away once the photographer moves.
+ */
+const TIME_WINDOW_SEC = 6;
 
 /** An asset enriched with the fields we need for clustering. */
 interface Clusterable {


### PR DESCRIPTION
Brackets still weren't grouping after the CR3 EXIF fix merged. Two things here, one to fix and one to diagnose.

1. TIME_WINDOW_SEC widened from 2.5s → 6s. 2.5s was tuned for AEB bursts (Canon/Sony fire 3 shots in ~0.3s) but missed every manual bracket where a photographer waits for the mirror to settle between exposures — common on tripod-mounted real-estate interiors where vibration kills sharpness. 6s still rejects unrelated scenes (next shot after moving is almost always >10s away).

2. New GET /api/photo/projects/:id/exif-diagnostic endpoint returns, per asset: captureTime, exposureBiasEv, exposureTimeSec, ISO, camera model, assigned bracketGroupId, and the gap-in-seconds to the previous frame. Lets us see at a glance whether captureTime parsed correctly and whether the time gaps would cluster under TIME_WINDOW_SEC. No writes, no secrets — safe to hit from curl.

Next time someone reports "brackets not grouping", the debugging loop is: hit the diagnostic endpoint, eyeball the gaps column, decide whether it's a parse bug or a clustering-threshold issue.