### PR TITLE
Log full EXIF table on every bracket-detect run

### DIFF
--- a/server/services/bracket-detection-service.ts
+++ b/server/services/bracket-detection-service.ts
@@ -85,6 +85,57 @@ export class BracketDetectionService {
         )
       );
 
+    console.log(
+      `\n🔎 BRACKET DETECT: project=${projectId} totalAssets=${assets.length} windowSec=${TIME_WINDOW_SEC}`
+    );
+
+    // Per-asset diagnostic table — dumped to server logs so "re-detect"
+    // becomes its own debugging tool.
+    const rawRows = assets.map((a) => {
+      const exif = a.exifData as {
+        captureTime?: string | null;
+        exposureBiasEv?: number | null;
+        exposureTimeSec?: number | null;
+      } | null;
+      return {
+        id: a.id,
+        fileName: a.fileName,
+        captureTime: exif?.captureTime ?? null,
+        exposureBiasEv: exif?.exposureBiasEv ?? null,
+        exposureTimeSec: exif?.exposureTimeSec ?? null,
+      };
+    });
+
+    const withTime = rawRows.filter((r) => r.captureTime);
+    const withoutTime = rawRows.filter((r) => !r.captureTime);
+
+    if (withoutTime.length > 0) {
+      console.log(
+        `   ⚠️  ${withoutTime.length}/${assets.length} assets have NO captureTime — they will never cluster:`
+      );
+      for (const r of withoutTime) {
+        console.log(`      · id=${r.id} file=${r.fileName} EV=${r.exposureBiasEv}`);
+      }
+    }
+
+    if (withTime.length > 0) {
+      const sorted = [...withTime].sort(
+        (a, b) => +new Date(a.captureTime!) - +new Date(b.captureTime!)
+      );
+      console.log(`   📷 ${withTime.length} assets with captureTime (sorted, with gap):`);
+      let prevMs: number | null = null;
+      for (const r of sorted) {
+        const ms = +new Date(r.captureTime!);
+        const gap = prevMs != null ? (ms - prevMs) / 1000 : null;
+        const gapStr =
+          gap == null ? "—" : `+${gap.toFixed(2)}s${gap <= TIME_WINDOW_SEC ? " ✓" : " ✗ (too far)"}`;
+        console.log(
+          `      · ${r.fileName} @ ${r.captureTime} EV=${r.exposureBiasEv} gap=${gapStr}`
+        );
+        prevMs = ms;
+      }
+    }
+
     const clusterable = assets
       .map((a) => {
         const exif = a.exifData as {
@@ -106,6 +157,10 @@ export class BracketDetectionService {
 
     const clusters = this.cluster(clusterable);
     const bracketClusters = clusters.filter((c) => c.length >= 2);
+
+    console.log(
+      `   🧮 clusters=${clusters.length} bracketClusters(≥2)=${bracketClusters.length} — ${bracketClusters.map((c) => c.length).join("+") || "none"}`
+    );
 
     // Atomic rebuild. We take the "delete + re-insert" approach because
     // bracket groups have no user-editable state yet (no confirmation,


### PR DESCRIPTION
The HTTP diagnostic endpoint from the previous commit needs a bearer token, which makes it a pain to hit from a browser address bar. Since every bracket-detect invocation already runs server-side, just dump the whole diagnostic table to the server console on each run — that way clicking the "Re-detect" button in the UI produces a readable report in the dev terminal with zero extra tooling.

Output per run:
  🔎 BRACKET DETECT: project=12 totalAssets=5 windowSec=6
     📷 5 assets with captureTime (sorted, with gap):
        · IMG_0117.CR3 @ 2025-04-18T10:23:15 EV=-2 gap=—
        · IMG_0118.CR3 @ 2025-04-18T10:23:16 EV=-1 gap=+0.85s ✓
        · IMG_0119.CR3 @ 2025-04-18T10:23:17 EV=0  gap=+0.92s ✓
        ...
     🧮 clusters=1 bracketClusters(≥2)=1 — 5

Flags any asset missing captureTime ("will never cluster"), and marks each gap as ✓ / ✗ against TIME_WINDOW_SEC so it's obvious when the issue is parsing vs threshold.