### PR TITLE
Add bulk delete for uploaded photos (single + multi-select)

### DIFF
--- a/client/src/pages/photos/detail.tsx
+++ b/client/src/pages/photos/detail.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRoute } from "wouter";
 import { Button } from "@/components/ui/button";
@@ -29,7 +37,9 @@ import {
   AlertTriangle,
   RefreshCw,
   Sparkles,
+  Trash2,
   Unlock,
+  X,
 } from "lucide-react";
 import type { PhotoAsset, PhotoProject } from "@shared/schema";
 import { CreditsChip } from "@/components/photos/credits-chip";
@@ -131,6 +141,82 @@ type BatchPlanResponse = {
   balance: number;
 };
 
+// -----------------------------------------------------------------------------
+// Selection + bulk-delete context
+// -----------------------------------------------------------------------------
+//
+// Photo thumbnails live in two different places — the flat "singles" grid
+// below and inline inside each bracket group card. Rather than thread
+// selection state down two separate prop trees, we expose it via a small
+// React Context scoped to the detail page. AssetThumbnail reads it
+// regardless of where it's rendered.
+//
+// The UX model is intentionally simple:
+//   - Every thumbnail gets a checkbox that appears on hover or when checked
+//   - Once any asset is selected, a sticky action bar slides in with a
+//     count + Delete + Cancel
+//   - Deleting runs the bulk endpoint, invalidates asset + bracket queries
+//     on success, and clears the selection
+
+type AssetSelectionContextValue = {
+  selectedIds: ReadonlySet<number>;
+  isSelected: (id: number) => boolean;
+  toggle: (id: number) => void;
+  clear: () => void;
+};
+
+const AssetSelectionContext = createContext<AssetSelectionContextValue | null>(
+  null
+);
+
+function useAssetSelection(): AssetSelectionContextValue {
+  const ctx = useContext(AssetSelectionContext);
+  if (!ctx) {
+    // A safe default for components that might render outside a provider
+    // (e.g. MergedPreview's before/after thumbnails have no selection UI).
+    const noop = () => {};
+    return {
+      selectedIds: new Set(),
+      isSelected: () => false,
+      toggle: noop,
+      clear: noop,
+    };
+  }
+  return ctx;
+}
+
+function AssetSelectionProvider({ children }: { children: React.ReactNode }) {
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(
+    () => new Set<number>()
+  );
+
+  const toggle = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+  const clear = useCallback(() => setSelectedIds(new Set()), []);
+
+  const value = useMemo<AssetSelectionContextValue>(
+    () => ({
+      selectedIds,
+      isSelected: (id: number) => selectedIds.has(id),
+      toggle,
+      clear,
+    }),
+    [selectedIds, toggle, clear]
+  );
+
+  return (
+    <AssetSelectionContext.Provider value={value}>
+      {children}
+    </AssetSelectionContext.Provider>
+  );
+}
+
 export default function PhotosDetail() {
   const [, params] = useRoute<{ id: string }>("/photos/:id");
   const id = params?.id;
@@ -207,7 +293,7 @@ export default function PhotosDetail() {
         )}
 
         {project && id && (
-          <>
+          <AssetSelectionProvider>
             <Card className="bg-white">
               <CardContent className="p-5">
                 <div className="flex items-start gap-4">
@@ -235,6 +321,8 @@ export default function PhotosDetail() {
 
             <UploadDropzone projectId={id} assetCount={assets.length} />
 
+            <SelectionActionBar projectId={id} />
+
             <BracketList
               projectId={id}
               groups={groups}
@@ -249,7 +337,7 @@ export default function PhotosDetail() {
               isError={assetsQuery.isError}
               label={groups.length > 0 ? "Singles" : "Source photos"}
             />
-          </>
+          </AssetSelectionProvider>
         )}
       </main>
     </div>
@@ -483,6 +571,224 @@ function AssetGrid({
         ))}
       </div>
     </section>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Selection action bar — shown only when at least one asset is selected.
+// -----------------------------------------------------------------------------
+//
+// We render this inside the normal page flow (below the upload dropzone)
+// rather than as a floating popover so it can't obscure bracket cards or
+// the photo grid on smaller screens. It's visually distinctive but not
+// modal — users can continue clicking other thumbnails to grow/shrink the
+// selection while it's open.
+
+type DeleteAssetsResponse = {
+  deleted: number;
+  deletedIds: number[];
+  skipped: number[];
+  brackets: { groupsCreated: number; assetsGrouped: number } | null;
+};
+
+type DeleteAssetsErrorBody = {
+  message?: string;
+  hasPaidDownloads?: boolean;
+};
+
+function SelectionActionBar({ projectId }: { projectId: string }) {
+  const { selectedIds, clear } = useAssetSelection();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [paidConfirmOpen, setPaidConfirmOpen] = useState(false);
+
+  const ids = useMemo(() => Array.from(selectedIds), [selectedIds]);
+
+  const deleteMutation = useMutation<
+    DeleteAssetsResponse,
+    Error,
+    { force: boolean }
+  >({
+    mutationFn: async ({ force }) => {
+      const res = await apiRequest(
+        "POST",
+        `/api/photo/projects/${projectId}/assets/delete`,
+        { assetIds: ids, force }
+      );
+      return (await res.json()) as DeleteAssetsResponse;
+    },
+    onSuccess: (data) => {
+      toast({
+        title: `Deleted ${data.deleted} photo${data.deleted === 1 ? "" : "s"}`,
+        description:
+          data.brackets && data.brackets.groupsCreated > 0
+            ? `${data.brackets.groupsCreated} bracket group${data.brackets.groupsCreated === 1 ? "" : "s"} remain`
+            : undefined,
+      });
+      clear();
+      setConfirmOpen(false);
+      setPaidConfirmOpen(false);
+      queryClient.invalidateQueries({
+        queryKey: [`/api/photo/projects/${projectId}/assets`],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [`/api/photo/projects/${projectId}/brackets`],
+      });
+    },
+    onError: async (err) => {
+      // apiRequest's throwIfResNotOk throws with a `<status>: <body>` string
+      // in the message — dig out the JSON body so we can detect the 409
+      // paid-download case and show the right confirm dialog.
+      const message = err.message ?? "";
+      let parsed: DeleteAssetsErrorBody | null = null;
+      const jsonStart = message.indexOf("{");
+      if (jsonStart >= 0) {
+        try {
+          parsed = JSON.parse(message.slice(jsonStart)) as DeleteAssetsErrorBody;
+        } catch {
+          parsed = null;
+        }
+      }
+      if (parsed?.hasPaidDownloads) {
+        setConfirmOpen(false);
+        setPaidConfirmOpen(true);
+        return;
+      }
+      toast({
+        title: "Delete failed",
+        description: parsed?.message ?? message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  if (ids.length === 0) return null;
+
+  return (
+    <>
+      <Card className="border-ailldoit-accent/30 bg-ailldoit-accent/5">
+        <CardContent className="p-3 flex items-center justify-between gap-3">
+          <div className="text-sm text-ailldoit-black font-medium">
+            {ids.length} selected
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clear}
+              disabled={deleteMutation.isPending}
+            >
+              <X className="w-4 h-4 mr-1" />
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setConfirmOpen(true)}
+              disabled={deleteMutation.isPending}
+            >
+              <Trash2 className="w-4 h-4 mr-1" />
+              Delete {ids.length}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Initial confirmation — the common case. */}
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          if (!deleteMutation.isPending) setConfirmOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Delete {ids.length} photo{ids.length === 1 ? "" : "s"}?
+            </DialogTitle>
+            <DialogDescription>
+              This removes the source {ids.length === 1 ? "file" : "files"},
+              any renditions derived from {ids.length === 1 ? "it" : "them"},
+              and archived RAW copies. This can't be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmOpen(false)}
+              disabled={deleteMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteMutation.mutate({ force: false })}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                  Deleting…
+                </>
+              ) : (
+                <>
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  Delete
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Secondary confirmation — paid-download case. Opens when the
+          server responds 409 { hasPaidDownloads: true }. Retries with
+          force=true, which also nukes the photo_downloads receipts. */}
+      <Dialog
+        open={paidConfirmOpen}
+        onOpenChange={(open) => {
+          if (!deleteMutation.isPending) setPaidConfirmOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Photos have paid downloads</DialogTitle>
+            <DialogDescription>
+              One or more of the selected photos have already been purchased
+              and downloaded. Deleting them will also permanently remove the
+              download receipts. Continue anyway?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setPaidConfirmOpen(false)}
+              disabled={deleteMutation.isPending}
+            >
+              Keep photos
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteMutation.mutate({ force: true })}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                  Deleting…
+                </>
+              ) : (
+                <>
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  Delete anyway
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
@@ -831,6 +1137,9 @@ function formatEv(v: number): string {
 
 function AssetThumbnail({ asset, compact = false }: { asset: PhotoAsset; compact?: boolean }) {
   const [imgError, setImgError] = useState(false);
+  const { isSelected, toggle } = useAssetSelection();
+  const selected = isSelected(asset.id);
+
   const exif = asset.exifData as {
     captureTime?: string | null;
     iso?: number | null;
@@ -840,8 +1149,21 @@ function AssetThumbnail({ asset, compact = false }: { asset: PhotoAsset; compact
   const captureTime = exif?.captureTime ? new Date(exif.captureTime) : null;
   const ev = typeof exif?.exposureBiasEv === "number" ? exif.exposureBiasEv : null;
 
+  // A single click on the tile toggles the selection — no "enter select
+  // mode" toggle. Keeps the model dead simple: click to pick, click again
+  // to unpick, Delete from the action bar.
+  const onThumbClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    toggle(asset.id);
+  };
+
   return (
-    <Card className="bg-white overflow-hidden">
+    <Card
+      className={`bg-white overflow-hidden group transition-shadow cursor-pointer ${
+        selected ? "ring-2 ring-ailldoit-accent" : "hover:shadow-md"
+      }`}
+      onClick={onThumbClick}
+    >
       <div className="aspect-square bg-gray-100 flex items-center justify-center relative">
         {imgError ? (
           <ImageOff className="w-8 h-8 text-gray-400" />
@@ -854,6 +1176,39 @@ function AssetThumbnail({ asset, compact = false }: { asset: PhotoAsset; compact
             loading="lazy"
           />
         )}
+
+        {/* Selection checkbox — shown on hover OR when selected. The
+            dedicated click handler lets users check/uncheck without
+            triggering the card's own click-to-toggle (they stack, which
+            is fine — both end up calling toggle()). */}
+        <button
+          type="button"
+          aria-label={selected ? "Deselect photo" : "Select photo"}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggle(asset.id);
+          }}
+          className={`absolute top-1 left-1 w-5 h-5 rounded border flex items-center justify-center transition-opacity ${
+            selected
+              ? "bg-ailldoit-accent border-ailldoit-accent opacity-100"
+              : "bg-white/90 border-gray-300 opacity-0 group-hover:opacity-100"
+          }`}
+        >
+          {selected ? (
+            <svg
+              className="w-3 h-3 text-white"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          ) : null}
+        </button>
+
         {compact && ev !== null ? (
           <span className="absolute bottom-1 right-1 text-[10px] font-mono text-white bg-black/60 rounded px-1">
             {ev > 0 ? `+${Number.isInteger(ev) ? ev : ev.toFixed(1)}` : Number.isInteger(ev) ? String(ev) : ev.toFixed(1)} EV

--- a/server/observability/posthog.ts
+++ b/server/observability/posthog.ts
@@ -60,6 +60,7 @@ function baseProps(): Record<string, unknown> {
 export type PhotoEvent =
   | "photo_project_created"
   | "photo_assets_uploaded"
+  | "photo_assets_deleted"
   | "photo_bracket_detected"
   | "photo_render_requested"
   | "photo_render_completed"

--- a/server/routes/photo-routes.ts
+++ b/server/routes/photo-routes.ts
@@ -323,6 +323,202 @@ router.get(
 );
 
 /**
+ * POST /api/photo/projects/:id/assets/delete
+ * Bulk delete source photos. Body: { assetIds: number[], force?: boolean }.
+ *
+ * Uses POST+body rather than DELETE with a querystring because ID lists
+ * can easily exceed URL length limits once a user selects dozens of photos,
+ * and most corporate proxies strip bodies from DELETE requests.
+ *
+ * If any target has paid download history we refuse with 409 so the UI can
+ * prompt the user to confirm — resending with force=true then hard-deletes
+ * everything including the receipts.
+ */
+router.post(
+  "/projects/:id/assets/delete",
+  async (req: Request, res: Response) => {
+    const projectId = Number(req.params.id);
+    if (!Number.isFinite(projectId) || projectId <= 0) {
+      return res.status(400).json({ message: "Invalid project id" });
+    }
+
+    // Accept either a single-id or array-of-ids shape. Clients pick
+    // whichever is more ergonomic.
+    const body = req.body as { assetIds?: unknown; force?: unknown };
+    const rawIds = Array.isArray(body.assetIds) ? body.assetIds : [];
+    const assetIds = rawIds
+      .map((v) => Number(v))
+      .filter((n) => Number.isFinite(n) && n > 0);
+    const force = body.force === true;
+
+    if (assetIds.length === 0) {
+      return res
+        .status(400)
+        .json({ message: "assetIds must be a non-empty array of ids" });
+    }
+
+    try {
+      await organizationService.requireMembership(
+        req.user!.id,
+        req.orgId!,
+        "editor"
+      );
+      const project = await photoProjectService.getByIdForOrg(
+        projectId,
+        req.orgId!
+      );
+      if (!project) {
+        return res.status(404).json({ message: "Project not found" });
+      }
+
+      const result = await photoAssetService.deleteAssets(assetIds, {
+        projectId,
+        force,
+      });
+
+      if (result.hasPaidDownloads) {
+        // 409 Conflict — the client should show a "this photo has paid
+        // downloads, delete anyway?" prompt and retry with force=true.
+        return res.status(409).json({
+          message:
+            "One or more photos have paid download receipts. Pass force=true to delete anyway.",
+          hasPaidDownloads: true,
+        });
+      }
+
+      // Re-run bracket detection so any cluster that now has <2 members
+      // disappears from the UI immediately. Cheap and idempotent.
+      let brackets: { groupsCreated: number; assetsGrouped: number } | null =
+        null;
+      try {
+        const detect = await bracketDetectionService.detectForProject(
+          projectId
+        );
+        brackets = {
+          groupsCreated: detect.groupsCreated,
+          assetsGrouped: detect.assetsGrouped,
+        };
+      } catch (detectErr: any) {
+        console.warn(
+          "⚠️ PHOTO: Post-delete bracket detection failed:",
+          detectErr?.message
+        );
+      }
+
+      trackEvent("photo_assets_deleted", {
+        userId: req.user!.id,
+        orgId: req.orgId!,
+        props: {
+          project_id: projectId,
+          deleted: result.deletedIds.length,
+          skipped: result.skippedIds.length,
+          forced: force,
+          storage_paths_failed: result.storagePathsFailed,
+        },
+      });
+
+      return res.json({
+        deleted: result.deletedIds.length,
+        deletedIds: result.deletedIds,
+        skipped: result.skippedIds,
+        brackets,
+      });
+    } catch (error: any) {
+      if (error.statusCode) {
+        return res
+          .status(error.statusCode)
+          .json({ message: error.message });
+      }
+      console.error("❌ PHOTO: Delete assets failed", error);
+      return res.status(500).json({ message: "Delete failed" });
+    }
+  }
+);
+
+/**
+ * DELETE /api/photo/projects/:id/assets/:assetId
+ * Convenience single-asset wrapper around the bulk delete service.
+ * Accepts `?force=true` to override the paid-download safety check.
+ */
+router.delete(
+  "/projects/:id/assets/:assetId",
+  async (req: Request, res: Response) => {
+    const projectId = Number(req.params.id);
+    const assetId = Number(req.params.assetId);
+    if (!Number.isFinite(projectId) || projectId <= 0) {
+      return res.status(400).json({ message: "Invalid project id" });
+    }
+    if (!Number.isFinite(assetId) || assetId <= 0) {
+      return res.status(400).json({ message: "Invalid asset id" });
+    }
+    const force = req.query.force === "true";
+
+    try {
+      await organizationService.requireMembership(
+        req.user!.id,
+        req.orgId!,
+        "editor"
+      );
+      const project = await photoProjectService.getByIdForOrg(
+        projectId,
+        req.orgId!
+      );
+      if (!project) {
+        return res.status(404).json({ message: "Project not found" });
+      }
+
+      const result = await photoAssetService.deleteAssets([assetId], {
+        projectId,
+        force,
+      });
+
+      if (result.hasPaidDownloads) {
+        return res.status(409).json({
+          message:
+            "This photo has paid download receipts. Retry with ?force=true to delete anyway.",
+          hasPaidDownloads: true,
+        });
+      }
+      if (result.deletedIds.length === 0) {
+        return res.status(404).json({ message: "Asset not found" });
+      }
+
+      // Bracket detection pass — see the bulk handler for context.
+      try {
+        await bracketDetectionService.detectForProject(projectId);
+      } catch (detectErr: any) {
+        console.warn(
+          "⚠️ PHOTO: Post-delete bracket detection failed:",
+          detectErr?.message
+        );
+      }
+
+      trackEvent("photo_assets_deleted", {
+        userId: req.user!.id,
+        orgId: req.orgId!,
+        props: {
+          project_id: projectId,
+          deleted: 1,
+          skipped: 0,
+          forced: force,
+          storage_paths_failed: result.storagePathsFailed,
+        },
+      });
+
+      return res.json({ deleted: 1 });
+    } catch (error: any) {
+      if (error.statusCode) {
+        return res
+          .status(error.statusCode)
+          .json({ message: error.message });
+      }
+      console.error("❌ PHOTO: Delete asset failed", error);
+      return res.status(500).json({ message: "Delete failed" });
+    }
+  }
+);
+
+/**
  * GET /api/photo/projects/:id/assets/:assetId/versions
  * Version chain for a single asset. Used by the detail page's history
  * strip — each merge/enhance/WB pass appends one row here.

--- a/server/services/photo-asset-service.ts
+++ b/server/services/photo-asset-service.ts
@@ -23,10 +23,13 @@
 
 import exifr from "exifr";
 import sharp from "sharp";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import { db } from "../db";
 import {
+  bracketGroups,
+  editVersions,
   photoAssets,
+  photoDownloads,
   type PhotoAsset,
   type InsertPhotoAsset,
 } from "@shared/schema";
@@ -187,6 +190,21 @@ export interface UploadedFile {
   mimetype: string;
   size: number;
   buffer: Buffer;
+}
+
+export interface DeleteAssetsResult {
+  /** Asset IDs actually removed from the DB (also from storage, best-effort). */
+  deletedIds: number[];
+  /** Asset IDs in the request that didn't belong to the project — ignored. */
+  skippedIds: number[];
+  /**
+   * True when at least one target asset had a paid-download receipt. In
+   * that case we refuse the operation (deletedIds is empty) unless the
+   * caller passed force=true, so the UI can surface an explicit warning.
+   */
+  hasPaidDownloads: boolean;
+  storagePathsAttempted: number;
+  storagePathsFailed: number;
 }
 
 export interface UploadContext {
@@ -425,6 +443,185 @@ export class PhotoAssetService {
   }
 
   /**
+   * Remove one or more source assets from a project. Scoped by projectId
+   * so a request for assets in another project is a no-op (never a
+   * cross-project leak).
+   *
+   * Safety rules:
+   *   - Paid downloads are NEVER silently destroyed. If any edit_version
+   *     derived from a target asset has a row in photo_downloads, the
+   *     deletion fails with `hasPaidDownloads: true` unless the caller
+   *     passes `force: true`. The UI uses this to require explicit
+   *     confirmation for assets a user has actually paid to download.
+   *   - DB deletion leans on the FK cascade chain already in schema.ts:
+   *     edit_jobs (assetId, outputAssetId), edit_versions (assetId), and
+   *     bracketGroups.bracketGroupId (set null) all clean up on their own.
+   *   - Orphaned bracket groups (mergedAssetId pointing at a deleted
+   *     asset) are fixed with a manual UPDATE since that FK was deferred
+   *     in schema.ts to avoid a circular reference.
+   *   - Firebase Storage objects are best-effort: we fire off the deletes
+   *     AFTER the DB transaction commits, and log-but-don't-throw on any
+   *     individual failure. Leftover blobs are a cleanup-job problem,
+   *     never a user-facing failure.
+   *   - Bracket detection re-runs on the project at the end so any clusters
+   *     that dropped below 2 members disappear from the UI.
+   */
+  async deleteAssets(
+    assetIds: number[],
+    ctx: { projectId: number; force?: boolean }
+  ): Promise<DeleteAssetsResult> {
+    if (assetIds.length === 0) {
+      return {
+        deletedIds: [],
+        skippedIds: [],
+        hasPaidDownloads: false,
+        storagePathsAttempted: 0,
+        storagePathsFailed: 0,
+      };
+    }
+
+    // 1. Resolve the assets — the projectId filter is the auth guard.
+    //    Caller has already checked org membership via photoProjectService.
+    const assets = await db
+      .select()
+      .from(photoAssets)
+      .where(
+        and(
+          eq(photoAssets.projectId, ctx.projectId),
+          inArray(photoAssets.id, assetIds)
+        )
+      );
+
+    const foundIds = assets.map((a) => a.id);
+    const skippedIds = assetIds.filter((id) => !foundIds.includes(id));
+
+    if (foundIds.length === 0) {
+      return {
+        deletedIds: [],
+        skippedIds,
+        hasPaidDownloads: false,
+        storagePathsAttempted: 0,
+        storagePathsFailed: 0,
+      };
+    }
+
+    // 2. Fetch the version chain for each asset — we need both the
+    //    Firebase URLs we'll clean up and the versionIds to check for
+    //    paid downloads.
+    const versions = await db
+      .select()
+      .from(editVersions)
+      .where(inArray(editVersions.assetId, foundIds));
+    const versionIds = versions.map((v) => v.id);
+
+    // 3. Paid-download safety check. If there's any download row for a
+    //    version in this set, block deletion unless explicitly forced.
+    let hasPaidDownloads = false;
+    if (versionIds.length > 0) {
+      const downloads = await db
+        .select({ id: photoDownloads.id })
+        .from(photoDownloads)
+        .where(inArray(photoDownloads.versionId, versionIds))
+        .limit(1);
+      hasPaidDownloads = downloads.length > 0;
+    }
+
+    if (hasPaidDownloads && !ctx.force) {
+      return {
+        deletedIds: [],
+        skippedIds: assetIds, // nothing got deleted, everything's on hold
+        hasPaidDownloads: true,
+        storagePathsAttempted: 0,
+        storagePathsFailed: 0,
+      };
+    }
+
+    // 4. Collect every Firebase URL we should try to clean up:
+    //    - source URL for each asset
+    //    - archived RAW (stashed in exifData.rawOriginal.archivedUrl)
+    //    - every version's outputUrl and cleanOutputUrl
+    const urls: string[] = [];
+    for (const a of assets) {
+      if (a.sourceUrl) urls.push(a.sourceUrl);
+      const exif = a.exifData as
+        | { rawOriginal?: { archivedUrl?: string | null } | null }
+        | null;
+      const archivedUrl = exif?.rawOriginal?.archivedUrl;
+      if (archivedUrl) urls.push(archivedUrl);
+    }
+    for (const v of versions) {
+      if (v.outputUrl) urls.push(v.outputUrl);
+      if (v.cleanOutputUrl) urls.push(v.cleanOutputUrl);
+    }
+
+    // 5. Delete inside a transaction: paid-download rows first (only
+    //    reachable with force=true), then assets. FK cascades take care
+    //    of edit_jobs + edit_versions. Bracket group orphan pointers
+    //    (mergedAssetId → deleted) get cleared with an explicit UPDATE.
+    await db.transaction(async (tx) => {
+      if (ctx.force && versionIds.length > 0) {
+        await tx
+          .delete(photoDownloads)
+          .where(inArray(photoDownloads.versionId, versionIds));
+      }
+
+      // Null any bracket group that pointed at one of these assets as
+      // its merged output — that group no longer has a rendered HDR.
+      await tx
+        .update(bracketGroups)
+        .set({ mergedAssetId: null, status: "detected" })
+        .where(
+          and(
+            eq(bracketGroups.projectId, ctx.projectId),
+            inArray(bracketGroups.mergedAssetId, foundIds)
+          )
+        );
+
+      await tx
+        .delete(photoAssets)
+        .where(
+          and(
+            eq(photoAssets.projectId, ctx.projectId),
+            inArray(photoAssets.id, foundIds)
+          )
+        );
+    });
+
+    // 6. Best-effort Firebase Storage cleanup. We do NOT await this in a
+    //    way that can fail the response — each URL gets its own try/catch.
+    let storagePathsFailed = 0;
+    const uniqueUrls = Array.from(new Set(urls));
+    await Promise.all(
+      uniqueUrls.map(async (url) => {
+        const storagePath = extractStoragePathFromUrl(url);
+        if (!storagePath) return;
+        try {
+          await firebaseStorageService.deleteFile(storagePath);
+        } catch (err: any) {
+          storagePathsFailed += 1;
+          console.warn(
+            `⚠️ PHOTO ASSET: Failed to delete storage object ${storagePath}:`,
+            err?.message
+          );
+        }
+      })
+    );
+
+    console.log(
+      `🗑️ PHOTO ASSET: project=${ctx.projectId} deleted=${foundIds.length} ` +
+        `skipped=${skippedIds.length} storage(ok/fail)=${uniqueUrls.length - storagePathsFailed}/${storagePathsFailed}`
+    );
+
+    return {
+      deletedIds: foundIds,
+      skippedIds,
+      hasPaidDownloads: false,
+      storagePathsAttempted: uniqueUrls.length,
+      storagePathsFailed,
+    };
+  }
+
+  /**
    * Parse EXIF + dimensions from a JPEG buffer. Returns nulls rather than
    * throwing when a field is missing — different camera bodies write
    * wildly different subsets and we'd rather ingest than fail.
@@ -521,6 +718,48 @@ export class PhotoAssetService {
       orientation,
       raw: parsed,
     };
+  }
+}
+
+/**
+ * Convert a Firebase Storage signed URL (or plain googleapis URL) back to
+ * the object path we can hand to firebaseStorageService.deleteFile().
+ *
+ * Handles both formats we emit:
+ *   - `https://storage.googleapis.com/<bucket>/<path>?signed-query`
+ *   - `https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<encoded-path>?...`
+ *
+ * Returns null for anything that isn't recognisable — the caller should
+ * skip cleanup rather than guess (guessing wrong could delete the wrong
+ * blob for another project).
+ */
+function extractStoragePathFromUrl(url: string): string | null {
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname;
+
+    // storage.googleapis.com/<bucket>/<path...>
+    if (host === "storage.googleapis.com") {
+      // pathname starts with "/" then bucket name. We don't know the
+      // bucket name at this layer, so just strip the first two segments:
+      //    /bucket-name/photo/orgId/...  → photo/orgId/...
+      const parts = parsed.pathname.split("/").filter(Boolean);
+      if (parts.length < 2) return null;
+      return parts.slice(1).join("/");
+    }
+
+    // firebasestorage.googleapis.com/v0/b/<bucket>/o/<url-encoded-path>
+    if (host === "firebasestorage.googleapis.com") {
+      const match = parsed.pathname.match(/\/v0\/b\/[^/]+\/o\/(.+)$/);
+      if (!match) return null;
+      return decodeURIComponent(match[1]);
+    }
+
+    return null;
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
Photos couldn't be removed after upload — screenshots, test files, and failed-EXIF RAWs were piling up in projects with no way to clean them out. Adds a delete flow covering:

Backend
  - POST /api/photo/projects/:id/assets/delete (body: assetIds + force)
  - DELETE /api/photo/projects/:id/assets/:assetId (convenience wrapper)
  - photoAssetService.deleteAssets() handles the full teardown: · paid-download safety check (409 unless force=true so the UI can surface an explicit "this was purchased — delete anyway?" prompt) · DB transaction leans on schema.ts FK cascades for edit_jobs + edit_versions; clears bracketGroups.mergedAssetId pointers · best-effort Firebase Storage cleanup from signed URLs (parses both storage.googleapis.com and firebasestorage.googleapis.com URL shapes; failures log-but-don't-throw so orphaned blobs never fail the user-facing operation) · re-runs bracket detection after the DB write so under-2 clusters disappear from the UI immediately
  - Adds "photo_assets_deleted" PostHog event for funnel tracking

Frontend (client/src/pages/photos/detail.tsx)
  - AssetSelectionContext + Provider wrap the project content; state lives at the page level so thumbnails in the flat grid AND inside bracket group cards share one selection set
  - AssetThumbnail renders a checkbox on hover (or when checked) and the whole card click-toggles — no explicit "selection mode"
  - SelectionActionBar appears under the upload dropzone whenever any asset is selected: count · Cancel · Delete N
  - Two-step confirm: primary Dialog for the common case, secondary "paid downloads detected" Dialog triggered by the 409 response — a second click retries with force=true