### PR TITLE
Fix CR3 EXIF: add ExifTool fallback for RAW files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
         "exifr": "^7.1.3",
+        "exiftool-vendored": "^30.0.0",
         "express": "^4.21.2",
         "express-rate-limit": "^7.4.1",
         "express-session": "^1.18.2",
@@ -3796,6 +3797,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@photostructure/tz-lookup": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-11.5.0.tgz",
+      "integrity": "sha512-0DVFriinZ7TeOnm9ytXeSL3NMFU87ZqMjgbPNkd8LgHFLcPg1BDyM1eewFYs+pPM+62S4fSP9Mtgijmn+6y95w==",
+      "license": "CC0-1.0"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -6363,6 +6370,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
+    },
     "node_modules/@types/memoizee": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
@@ -6999,6 +7012,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/batch-cluster": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/batch-cluster/-/batch-cluster-15.0.1.tgz",
+      "integrity": "sha512-eUmh0ld1AUPKTEmdzwGF9QTSexXAyt9rA1F5zDfW1wUi3okA3Tal4NLdCeFI6aiKpBenQhR6NmK9bW9tBHTGPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/bignumber.js": {
@@ -9187,6 +9209,49 @@
       "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
       "license": "MIT"
     },
+    "node_modules/exiftool-vendored": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-30.5.0.tgz",
+      "integrity": "sha512-m3fSrpFxmrT1VYl+/4mTyaYrgpe+key1QLmsWezDDkfJI3dF8ZrXn4gUuOctDBNKEKw6x4hGoQpIoWEsO6rxvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@photostructure/tz-lookup": "^11.2.1",
+        "@types/luxon": "^3.7.1",
+        "batch-cluster": "^15.0.1",
+        "he": "^1.2.0",
+        "luxon": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "exiftool-vendored.exe": "13.35.1",
+        "exiftool-vendored.pl": "13.35.0"
+      }
+    },
+    "node_modules/exiftool-vendored.exe": {
+      "version": "13.35.1",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-13.35.1.tgz",
+      "integrity": "sha512-RlgXYbsFYJKw9ICYx31cnpJRr94CEhp6VaJVFHJz4WQaHnJNZ5WvQZ7sZBF8B4P+dx0nQrmCwiAm9GGUQBzluw==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/exiftool-vendored.pl": {
+      "version": "13.35.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-13.35.0.tgz",
+      "integrity": "sha512-8sooj1fkS2Zvb2uflcp/l21la3xKJbPz7MONlWyjBAp0wZA1xtbz8S9+DLvMNRV5udPi5e6mOrIsi5gRhTN8jQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!win32"
+      ],
+      "bin": {
+        "exiftool": "bin/exiftool"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -10282,6 +10347,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hosted-git-info": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",
     "exifr": "^7.1.3",
+    "exiftool-vendored": "^30.0.0",
     "express": "^4.21.2",
     "express-rate-limit": "^7.4.1",
     "express-session": "^1.18.2",

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,6 +12,7 @@ initSentry();
 // PostHog init is order-insensitive (no network patching), but we start it
 // here so the funnel is live before the first route handler runs.
 import { initPostHog, shutdownPostHog } from "./observability/posthog";
+import { exiftool } from "exiftool-vendored";
 initPostHog();
 
 import express from "express";
@@ -169,6 +170,14 @@ app.use((req, res, next) => {
       await shutdownPostHog();
     } catch (err: any) {
       console.error("⚠️ SERVER: posthog shutdown errored:", err?.message ?? err);
+    }
+    // Kill the long-running ExifTool daemon so Cloud Run doesn't leak
+    // Perl subprocesses on scale-down. exiftool-vendored keeps a pool
+    // of processes open for fast repeat reads — we end them here.
+    try {
+      await exiftool.end();
+    } catch (err: any) {
+      console.error("⚠️ SERVER: exiftool shutdown errored:", err?.message ?? err);
     }
     httpServer.close(() => {
       console.log("👋 SERVER: closed HTTP server, bye");

--- a/server/services/photo-asset-service.ts
+++ b/server/services/photo-asset-service.ts
@@ -22,6 +22,11 @@
  */
 
 import exifr from "exifr";
+import { exiftool, ExifDateTime } from "exiftool-vendored";
+import { writeFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import sharp from "sharp";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import { db } from "../db";
@@ -185,6 +190,77 @@ async function extractRawPreview(buffer: Buffer): Promise<Buffer | null> {
   return null;
 }
 
+/**
+ * Shell out to ExifTool for formats exifr can't handle.
+ *
+ * Why this exists: exifr is great for JPEGs but its ISOBMFF support is
+ * flaky — Canon's CR3 is ISOBMFF-based, and in practice we're seeing
+ * zero-key parses from BOTH the CR3 container and the embedded preview
+ * JPEG Canon emits (Canon firmware strips EXIF from the preview). ExifTool
+ * is the 20-year-old Perl tool that handles every RAW container correctly,
+ * and `exiftool-vendored` ships the binary inside node_modules so there's
+ * no system-level install — works on Mac dev + Cloud Run (both arches).
+ *
+ * ExifTool needs a real seekable file (the CR3 container requires
+ * random-access reads), so we stage the buffer in /tmp and clean up
+ * afterwards. The exiftool-vendored daemon keeps a long-lived Perl
+ * process around so repeat calls are cheap (~30ms per file after warmup).
+ *
+ * Returns the raw ExifTool tag bag — it's up to the caller to map the
+ * field names into our ExtractedExif shape (ExifTool uses slightly
+ * different names than exifr in a few places).
+ */
+async function parseExifWithExiftool(
+  buffer: Buffer,
+  originalName: string
+): Promise<Record<string, unknown>> {
+  const safeName = originalName.replace(/[^\w.-]+/g, "_").slice(0, 80);
+  const tempPath = join(
+    tmpdir(),
+    `ailldoit_exif_${randomUUID()}_${safeName}`
+  );
+  try {
+    await writeFile(tempPath, buffer);
+    const tags = await exiftool.read(tempPath);
+    return tags as unknown as Record<string, unknown>;
+  } finally {
+    // Best-effort cleanup; OS-level tmp reap covers any leaks anyway.
+    try {
+      await unlink(tempPath);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * ExifTool dates come back as ExifDateTime objects (not native Date).
+ * Normalise to an ISO-8601 string so the rest of our coercion pipeline
+ * (coerceCaptureTime) treats them uniformly. ExifDateTime's .toDate()
+ * yields a JS Date in local-system time if no zone was parsed, which is
+ * close enough for our purposes — bracket clustering only needs relative
+ * ordering within a 6-second window, not true UTC.
+ */
+function exifToolDateToIsoString(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  if (typeof v === "string") return v;
+  if (v instanceof ExifDateTime) {
+    try {
+      const d = v.toDate();
+      return d instanceof Date && !Number.isNaN(+d) ? d.toISOString() : undefined;
+    } catch {
+      // Fallback: rawValue is "YYYY:MM:DD HH:mm:ss" — coerceCaptureTime
+      // knows how to handle that format.
+      return (v as any).rawValue ?? String(v);
+    }
+  }
+  if (v instanceof Date) {
+    return Number.isNaN(+v) ? undefined : v.toISOString();
+  }
+  // Last resort — stringify and let coerceCaptureTime figure it out.
+  return String(v);
+}
+
 export interface UploadedFile {
   originalname: string;
   mimetype: string;
@@ -305,11 +381,31 @@ export class PhotoAssetService {
       isRaw ? `${file.originalname}:preview` : `${file.originalname}`
     );
     if (isRaw && !exif.captureTime) {
+      // Stage 1 fallback: re-parse the original RAW buffer with exifr.
+      // Cheap, no shell-out. Works for some TIFF-based RAW bodies.
       const fallback = await this.parseExif(
         file.buffer,
         `${file.originalname}:raw-fallback`
       );
       exif = mergeExifPreferringNonNull(exif, fallback);
+    }
+    if (isRaw && !exif.captureTime) {
+      // Stage 2 fallback: ExifTool on the original RAW. This is the
+      // reliable path for CR3 (Canon strips EXIF from preview JPEGs,
+      // and exifr's ISOBMFF support can't pull it from the container).
+      // We only reach here when exifr has failed twice, so the cost of
+      // a subprocess call is justified.
+      try {
+        const exiftoolResult = await this.parseExifViaExiftool(
+          file.buffer,
+          `${file.originalname}:exiftool-raw`
+        );
+        exif = mergeExifPreferringNonNull(exif, exiftoolResult);
+      } catch (err: any) {
+        console.error(
+          `❌ PHOTO ASSET: ExifTool fallback failed for ${file.originalname}: ${err?.message ?? err}`
+        );
+      }
     }
     if (isRaw && !exif.captureTime) {
       console.warn(
@@ -717,6 +813,104 @@ export class PhotoAssetService {
       heightPx,
       orientation,
       raw: parsed,
+    };
+  }
+
+  /**
+   * ExifTool-backed EXIF parse. Use this for RAW files (CR3/CR2/DNG/
+   * NEF/ARW/RAF) where exifr's own parse returns zero keys — ExifTool
+   * knows every camera body's quirks and handles Canon's CR3 ISOBMFF
+   * container correctly.
+   *
+   * Returns the SAME ExtractedExif shape as `parseExif()` so callers can
+   * swap or merge freely. Field mapping notes:
+   *   - exifr: ExposureBiasValue       ExifTool: ExposureCompensation
+   *   - exifr: ISO                     ExifTool: ISO
+   *   - exifr: DateTimeOriginal        ExifTool: DateTimeOriginal (ExifDateTime)
+   *   - exifr: ExifImageWidth          ExifTool: ImageWidth / ExifImageWidth
+   *
+   * We prefer the "original" timestamp over CreateDate over ModifyDate,
+   * same as the exifr path, so bracket clustering stays consistent.
+   */
+  async parseExifViaExiftool(
+    buffer: Buffer,
+    tag: string = "buffer"
+  ): Promise<ExtractedExif> {
+    const magic = describeMagic(buffer);
+    let tags: Record<string, unknown> = {};
+    try {
+      tags = await parseExifWithExiftool(buffer, tag);
+    } catch (err: any) {
+      console.error(
+        `❌ PHOTO ASSET [parseExifViaExiftool ${tag}]: exiftool threw — ${err?.message ?? err}`
+      );
+      return {
+        captureTime: null,
+        exposureTimeSec: null,
+        exposureBiasEv: null,
+        iso: null,
+        fNumber: null,
+        focalLengthMm: null,
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        widthPx: null,
+        heightPx: null,
+        orientation: null,
+        raw: {},
+      };
+    }
+
+    const keyCount = Object.keys(tags).length;
+    const dtoRaw = tags.DateTimeOriginal ?? tags.CreateDate ?? tags.ModifyDate;
+    const captureTime = coerceCaptureTime(exifToolDateToIsoString(dtoRaw));
+
+    console.log(
+      `📷 PHOTO ASSET [parseExifViaExiftool ${tag}]: size=${buffer.length} magic=${magic} ` +
+        `keys=${keyCount} DateTimeOriginal=${captureTime ?? "∅"} ` +
+        `Model=${tags.Model ?? "∅"} ISO=${tags.ISO ?? "∅"} ` +
+        `EV=${tags.ExposureCompensation ?? tags.ExposureBiasValue ?? "∅"}`
+    );
+
+    // ExifTool-vendored returns ExifDateTime / ExifTime objects that don't
+    // survive JSON.stringify cleanly. Normalise date-ish values to ISO
+    // strings so the `raw` blob we persist in exif_data is readable later.
+    const normalisedRaw: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(tags)) {
+      if (v instanceof ExifDateTime) {
+        normalisedRaw[k] = exifToolDateToIsoString(v) ?? String(v);
+      } else if (v instanceof Date) {
+        normalisedRaw[k] = Number.isNaN(+v) ? null : v.toISOString();
+      } else {
+        normalisedRaw[k] = v;
+      }
+    }
+
+    const iso = numberOrNull(tags.ISO);
+    const fNumber = numberOrNull(tags.FNumber ?? tags.Aperture);
+    const focalLengthMm = numberOrNull(tags.FocalLength);
+    const exposureTimeSec = numberOrNull(tags.ExposureTime);
+    const exposureBiasEv = numberOrNull(
+      tags.ExposureCompensation ?? tags.ExposureBiasValue
+    );
+    const widthPx = numberOrNull(tags.ExifImageWidth ?? tags.ImageWidth);
+    const heightPx = numberOrNull(tags.ExifImageHeight ?? tags.ImageHeight);
+    const orientation = numberOrNull(tags.Orientation);
+
+    return {
+      captureTime,
+      exposureTimeSec,
+      exposureBiasEv,
+      iso,
+      fNumber,
+      focalLengthMm,
+      cameraMake: stringOrNull(tags.Make),
+      cameraModel: stringOrNull(tags.Model),
+      lensModel: stringOrNull(tags.LensModel ?? tags.LensMake ?? tags.Lens),
+      widthPx,
+      heightPx,
+      orientation,
+      raw: normalisedRaw,
     };
   }
 }


### PR DESCRIPTION
Root cause:
  - exifr parses JPEG EXIF perfectly but its ISOBMFF support is flaky
  - Canon's CR3 container: zero-key parse from container itself
  - Canon's embedded preview JPEG: Canon firmware strips APP1/EXIF from the preview, so preview-JPEG fallback also came back with zero keys
  - Result: every CR3 uploaded had captureTime=null and never clustered

Fix:
  - Add exiftool-vendored (npm pkg bundling the ExifTool binary, no system-level install needed; works on Mac/Linux/Cloud Run)
  - New parseExifViaExiftool() returns the same ExtractedExif shape
  - ingestOne now has a 3-stage fallback for RAW files:
      1. exifr on the extracted preview JPEG (fast path, common case)
      2. exifr on the raw buffer (TIFF-based RAWs sometimes work) 3. ExifTool on the raw buffer (reliable CR3/CR2/DNG/NEF/ARW/RAF)
  - Graceful shutdown hook ends the exiftool daemon so Cloud Run scale-down doesn't leak Perl subprocesses

JPEG path is unchanged — still just exifr, no subprocess cost.